### PR TITLE
Fix metric registry check

### DIFF
--- a/src/expectations/metrics/batch_builder.py
+++ b/src/expectations/metrics/batch_builder.py
@@ -14,7 +14,7 @@ from typing import List, Optional, Sequence
 
 from sqlglot import exp, parse_one, select
 
-from src.expectations.metrics.registry import get_metric
+from src.expectations.metrics.registry import get_metric, available_metrics
 
 # --------------------------------------------------------------------------- #
 # Public request model                                                        #
@@ -44,7 +44,8 @@ class MetricBatchBuilder:
         self.requests = list(requests)
         self.dialect = dialect
 
-        unknown = {r.metric for r in self.requests if r.metric not in get_metric.__wrapped__.__closure__[0].cell_contents}  # type: ignore
+        known = set(available_metrics())
+        unknown = {r.metric for r in self.requests if r.metric not in known}
         if unknown:
             raise ValueError(f"Unknown metrics: {', '.join(sorted(unknown))}")
 


### PR DESCRIPTION
## Summary
- correctly import `available_metrics`
- build `known` metric set using `available_metrics`

## Testing
- `python3 test.py` *(fails: TypeError in registry metrics)*

------
https://chatgpt.com/codex/tasks/task_e_6881d6e92df0832ab07e523a1a49d7a8