### PR TITLE
Expand validation rules

### DIFF
--- a/src/expectations/metrics/registry.py
+++ b/src/expectations/metrics/registry.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import Callable, Dict, Tuple
 
-from sqlglot import exp
+from sqlglot import exp, parse_one
 
 # --------------------------------------------------------------------------- #
 # Public typing alias                                                         #
@@ -34,6 +34,7 @@ MetricBuilder = Callable[[str], exp.Expression]
 # Internal registry dictionary                                                #
 # --------------------------------------------------------------------------- #
 _METRICS: Dict[str, MetricBuilder] = {}
+
 
 # --------------------------------------------------------------------------- #
 # Helper functions                                                             #
@@ -72,8 +73,9 @@ def get_metric(name: str) -> MetricBuilder:
     try:
         return _METRICS[name]
     except KeyError as exc:  # pragma: no cover
-        raise KeyError(f"Unknown metric key '{name}'. "
-                       f"Available: {', '.join(sorted(_METRICS))}") from exc
+        raise KeyError(
+            f"Unknown metric key '{name}'. " f"Available: {', '.join(sorted(_METRICS))}"
+        ) from exc
 
 
 def available_metrics() -> Tuple[str, ...]:
@@ -95,7 +97,7 @@ def _null_pct(column: str) -> exp.Expression:
         .when(exp.Is(this=col_expr, expression=exp.null()), exp.Literal.number(1))
         .else_(exp.Literal.number(0))
     )
-    sum_nulls  = exp.Sum(this=case_expr)
+    sum_nulls = exp.Sum(this=case_expr)
     count_rows = exp.Count(this=exp.Star())
 
     # Use exp.Div (division) – correct class name in sqlglot
@@ -125,3 +127,43 @@ def _min(column: str) -> exp.Expression:
 def _max(column: str) -> exp.Expression:
     """MAX(col)"""
     return exp.Max(this=exp.column(column))
+
+
+@register_metric("non_null_cnt")
+def _non_null_cnt(column: str) -> exp.Expression:
+    """COUNT(CASE WHEN col IS NOT NULL THEN 1 END)"""
+    col_expr = exp.column(column)
+    case_expr = (
+        exp.Case()
+        .when(exp.Is(this=col_expr, expression=exp.null()), exp.null())
+        .else_(exp.Literal.number(1))
+    )
+    return exp.Count(this=case_expr)
+
+
+@register_metric("avg")
+def _avg(column: str) -> exp.Expression:
+    """AVG(col)"""
+    return exp.Avg(this=exp.column(column))
+
+
+@register_metric("stddev")
+def _stddev(column: str) -> exp.Expression:
+    """STDDEV_SAMP(col)"""
+    return exp.StddevSamp(this=exp.column(column))
+
+
+def pct_where(predicate_sql: str) -> MetricBuilder:
+    """Return a metric builder for ``pct_where`` using *predicate_sql*."""
+
+    def _builder(_: str) -> exp.Expression:
+        case_expr = (
+            exp.Case()
+            .when(parse_one(predicate_sql), exp.Literal.number(1))
+            .else_(exp.Literal.number(0))
+        )
+        sum_true = exp.Sum(this=case_expr)
+        count_rows = exp.Count(this=exp.Star())
+        return exp.Div(this=sum_true, expression=count_rows)
+
+    return _builder

--- a/src/expectations/validators/column.py
+++ b/src/expectations/validators/column.py
@@ -27,8 +27,6 @@ from src.expectations.metrics.registry import register_metric, get_metric
 from src.expectations.validators.base import ValidatorBase
 
 
-
-
 # --------------------------------------------------------------------------- #
 # Helper mix-in                                                               #
 # --------------------------------------------------------------------------- #
@@ -158,3 +156,153 @@ class ColumnMax(ColumnMetricValidator):
         if self.strict:
             return self.observed_max < self.max_value
         return self.observed_max <= self.max_value
+
+
+class ColumnValueInSet(ColumnMetricValidator):
+    """Passes when all values are within ``allowed_values``.
+
+    Example YAML::
+
+        - expectation_type: ColumnValueInSet
+          column: status
+          allowed_values: [OPEN, CLOSED]
+    """
+
+    _metric_key = "row_cnt"
+
+    def __init__(
+        self, *, column: str, allowed_values: list[str], allow_null: bool = False, **kw
+    ):
+        if not allowed_values:
+            raise ValueError("allowed_values must not be empty")
+        super().__init__(column=column, **kw)
+        self.allowed_values = allowed_values
+        self.allow_null = allow_null
+
+    def metric_request(self) -> MetricRequest:
+        vals = ", ".join(f"'{v}'" for v in self.allowed_values)
+        cond = f"{self.column} NOT IN ({vals})"
+        if not self.allow_null:
+            cond += f" OR {self.column} IS NULL"
+        return MetricRequest(
+            column=self.column,
+            metric=self._metric_key,
+            alias=self.runtime_id,
+            filter_sql=cond,
+        )
+
+    def interpret(self, value) -> bool:
+        if value is None or (isinstance(value, float) and value != value):
+            self.invalid_cnt = 0
+        else:
+            self.invalid_cnt = int(value)
+        return self.invalid_cnt == 0
+
+
+class ColumnMatchesRegex(ColumnMetricValidator):
+    """Passes when every value matches ``pattern``.
+
+    Example YAML::
+
+        - expectation_type: ColumnMatchesRegex
+          column: email
+          pattern: "^[A-Za-z]+@example.com$"
+    """
+
+    _metric_key = "row_cnt"
+
+    def __init__(self, *, column: str, pattern: str, **kw):
+        super().__init__(column=column, **kw)
+        self.pattern = pattern
+
+    def metric_request(self) -> MetricRequest:
+        cond = f"NOT REGEXP_LIKE({self.column}, '{self.pattern}')"
+        return MetricRequest(
+            column=self.column,
+            metric=self._metric_key,
+            alias=self.runtime_id,
+            filter_sql=cond,
+        )
+
+    def interpret(self, value) -> bool:
+        if value is None or (isinstance(value, float) and value != value):
+            self.invalid_cnt = 0
+        else:
+            self.invalid_cnt = int(value)
+        return self.invalid_cnt == 0
+
+
+class ColumnRange(ColumnMetricValidator):
+    """Passes when values fall between ``min_value`` and ``max_value``.
+
+    Example YAML::
+
+        - expectation_type: ColumnRange
+          column: price
+          min_value: 0
+          max_value: 100
+    """
+
+    _metric_key = "row_cnt"
+
+    def __init__(
+        self, *, column: str, min_value: Any, max_value: Any, strict: bool = False, **kw
+    ):
+        super().__init__(column=column, **kw)
+        self.min_value = min_value
+        self.max_value = max_value
+        self.strict = strict
+
+    def metric_request(self) -> MetricRequest:
+        if self.strict:
+            cond = f"{self.column} <= {self.min_value} OR {self.column} >= {self.max_value}"
+        else:
+            cond = (
+                f"{self.column} < {self.min_value} OR {self.column} > {self.max_value}"
+            )
+        return MetricRequest(
+            column=self.column,
+            metric=self._metric_key,
+            alias=self.runtime_id,
+            filter_sql=cond,
+        )
+
+    def interpret(self, value) -> bool:
+        if value is None or (isinstance(value, float) and value != value):
+            self.out_of_range_cnt = 0
+        else:
+            self.out_of_range_cnt = int(value)
+        return self.out_of_range_cnt == 0
+
+
+class ColumnGreaterEqual(ColumnMetricValidator):
+    """Passes when ``column`` ≥ ``other_column`` row-wise.
+
+    Example YAML::
+
+        - expectation_type: ColumnGreaterEqual
+          column: end_date
+          other_column: start_date
+    """
+
+    _metric_key = "row_cnt"
+
+    def __init__(self, *, column: str, other_column: str, **kw):
+        super().__init__(column=column, **kw)
+        self.other_column = other_column
+
+    def metric_request(self) -> MetricRequest:
+        cond = f"{self.column} < {self.other_column}"
+        return MetricRequest(
+            column=self.column,
+            metric=self._metric_key,
+            alias=self.runtime_id,
+            filter_sql=cond,
+        )
+
+    def interpret(self, value) -> bool:
+        if value is None or (isinstance(value, float) and value != value):
+            self.invalid_cnt = 0
+        else:
+            self.invalid_cnt = int(value)
+        return self.invalid_cnt == 0

--- a/src/expectations/validators/table.py
+++ b/src/expectations/validators/table.py
@@ -101,12 +101,49 @@ class DuplicateRowValidator(ValidatorBase):
             ) d
         """
         inner = (
-            exp.select(*map(exp.column, self.key_cols), exp.Count(this=exp.Star()).as_("c"))
+            exp.select(
+                *map(exp.column, self.key_cols), exp.Count(this=exp.Star()).as_("c")
+            )
             .from_(table)
             .group_by(*map(exp.column, self.key_cols))
             .having(exp.GT(this=exp.column("c"), expression=exp.Literal.number(1)))
         )
-        return exp.select(exp.Count(this=exp.Star()).as_("dup_cnt")).from_(inner.subquery("d"))
+        return exp.select(exp.Count(this=exp.Star()).as_("dup_cnt")).from_(
+            inner.subquery("d")
+        )
+
+    def interpret(self, value) -> bool:
+        self.duplicate_cnt = int(value)
+        return self.duplicate_cnt == 0
+
+
+class PrimaryKeyUniquenessValidator(ValidatorBase):
+    """Passes when the set of ``key_columns`` uniquely identifies each row.
+
+    Example YAML::
+
+        - expectation_type: PrimaryKeyUniquenessValidator
+          key_columns: [id]
+    """
+
+    def __init__(self, *, key_columns: Sequence[str]):
+        super().__init__()
+        if not key_columns:
+            raise ValueError("key_columns must be a non-empty list")
+        self.key_cols = list(key_columns)
+
+    @classmethod
+    def kind(cls):
+        return "custom"
+
+    def custom_sql(self, table: str):
+        distinct = exp.Count(
+            this=exp.Distinct(expressions=[exp.column(c) for c in self.key_cols])
+        )
+        diff = exp.Sub(this=exp.Count(this=exp.Star()), expression=distinct).as_(
+            "dup_cnt"
+        )
+        return exp.select(diff).from_(table)
 
     def interpret(self, value) -> bool:
         self.duplicate_cnt = int(value)

--- a/tests/test_metric_builders.py
+++ b/tests/test_metric_builders.py
@@ -35,3 +35,19 @@ def test_min_max():
     df = eng.run_sql(select(min_expr, max_expr).from_("t"))
     assert df.iloc[0]["mn"] == 1
     assert df.iloc[0]["mx"] == 5
+
+
+def test_extra_metrics():
+    eng = DuckDBEngine()
+    eng.register_dataframe("t", pd.DataFrame({"a": [1, 2, None]}))
+
+    nn_expr = get_metric("non_null_cnt")("a")
+    avg_expr = get_metric("avg")("a")
+    stddev_expr = get_metric("stddev")("a")
+
+    df = eng.run_sql(
+        select(nn_expr.as_("nn"), avg_expr.as_("avg"), stddev_expr.as_("sd")).from_("t")
+    )
+    assert df.iloc[0]["nn"] == 2
+    assert df.iloc[0]["avg"] == approx(1.5)
+    assert df.iloc[0]["sd"] == approx((0.5) ** 0.5)

--- a/tests/test_table_validators.py
+++ b/tests/test_table_validators.py
@@ -2,7 +2,11 @@ import pandas as pd
 
 from src.expectations.engines.duckdb import DuckDBEngine
 from src.expectations.runner import ValidationRunner
-from src.expectations.validators.table import RowCountValidator, DuplicateRowValidator
+from src.expectations.validators.table import (
+    RowCountValidator,
+    DuplicateRowValidator,
+    PrimaryKeyUniquenessValidator,
+)
 
 
 def _run(eng, table, validator):
@@ -29,5 +33,22 @@ def test_duplicate_row_validator():
     eng.register_dataframe("dup", df_dup)
     eng.register_dataframe("ok", df_ok)
 
-    assert _run(eng, "dup", DuplicateRowValidator(key_columns=["a", "b"])).success is False
-    assert _run(eng, "ok", DuplicateRowValidator(key_columns=["a", "b"])).success is True
+    assert (
+        _run(eng, "dup", DuplicateRowValidator(key_columns=["a", "b"])).success is False
+    )
+    assert (
+        _run(eng, "ok", DuplicateRowValidator(key_columns=["a", "b"])).success is True
+    )
+
+
+def test_primary_key_uniqueness():
+    eng = DuckDBEngine()
+    df = pd.DataFrame({"id": [1, 1, 2]})
+    eng.register_dataframe("t", df)
+    v = PrimaryKeyUniquenessValidator(key_columns=["id"])
+    assert _run(eng, "t", v).success is False
+    eng.register_dataframe("t2", pd.DataFrame({"id": [1, 2]}))
+    assert (
+        _run(eng, "t2", PrimaryKeyUniquenessValidator(key_columns=["id"])).success
+        is True
+    )


### PR DESCRIPTION
## Summary
- extend metric registry with avg/stddev/non-null count
- support predicate-based pct_where metric builder
- implement new column validators for enums, regex, ranges and relational checks
- add primary key uniqueness validator
- fix metric filter handling and extend tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c43af708832abaa709ebdc546819