### PR TITLE
Implement SqlErrorRows custom validator

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,0 +1,14 @@
+# Cookbook
+
+## Writing Custom Rules
+
+You can supply your own SQL and have the runner fail when that query returns rows.
+
+```yaml
+- expectation_type: SqlErrorRows
+  sql: |
+    SELECT * FROM your_table WHERE bad_condition
+  max_error_rows: 10  # optional
+```
+
+The validator will attach `error_row_count` and a sample of rows to the validation result.

--- a/src/expectations/runner.py
+++ b/src/expectations/runner.py
@@ -98,14 +98,15 @@ class ValidationRunner:
             err = ""
             try:
                 df = engine.run_sql(sql)
-                # convention: custom validators look at *first scalar* of first row
-                raw_val = df.iloc[0, 0] if not df.empty else None
-                ok = v.interpret(raw_val)
+                ok = v.interpret(df)
+                raw_val = None
             except Exception as exc:  # pylint: disable=broad-except
                 ok = False
                 raw_val = None
                 err = str(exc)
 
+            base_details = getattr(v, "details", {})
+            details = base_details if ok else {**base_details, "error": err}
             results.append(
                 ValidationResult(
                     run_id="",
@@ -114,7 +115,7 @@ class ValidationRunner:
                     column=getattr(v, "column", None),
                     success=ok,
                     value=raw_val,
-                    details={} if ok else {"error": err},
+                    details=details,
                 )
             )
 

--- a/src/expectations/validators/custom.py
+++ b/src/expectations/validators/custom.py
@@ -1,0 +1,52 @@
+"""Custom SQL validators."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pandas as pd
+
+from src.expectations.validators.base import ValidatorBase
+
+
+class SqlErrorRowsValidator(ValidatorBase):
+    """Run ad-hoc SQL that returns error rows.
+
+    Example YAML::
+
+        - expectation_type: SqlErrorRows
+          sql: |
+            SELECT * FROM my_table WHERE bad_condition
+          max_error_rows: 10
+    """
+
+    def __init__(
+        self,
+        *,
+        sql: str,
+        max_error_rows: int = 20,
+        severity: str = "FAIL",
+        tags: list[str] | None = None,
+    ):
+        super().__init__()
+        self.sql_text = sql
+        self.max_error_rows = max_error_rows
+        self.severity = severity
+        self.tags = tags or []
+        self.error_row_count = 0
+        self.details: dict = {}
+
+    @classmethod
+    def kind(cls) -> Literal["custom"]:
+        return "custom"
+
+    def custom_sql(self, table: str):
+        return self.sql_text
+
+    def interpret(self, df: pd.DataFrame) -> bool:
+        self.error_row_count = len(df)
+        self.details = {
+            "error_row_count": self.error_row_count,
+            "error_rows_sample": df.head(self.max_error_rows).to_dict("records"),
+        }
+        return self.error_row_count == 0

--- a/src/expectations/validators/table.py
+++ b/src/expectations/validators/table.py
@@ -13,12 +13,12 @@ from __future__ import annotations
 
 from typing import List, Sequence
 
+import pandas as pd
+
 from sqlglot import exp
 
 from src.expectations.metrics.batch_builder import MetricRequest
 from src.expectations.validators.base import ValidatorBase
-from src.expectations.metrics.registry import register_metric
-from src.expectations.metrics.registry import available_metrics as _avail
 
 
 # --------------------------------------------------------------------------- #
@@ -113,8 +113,12 @@ class DuplicateRowValidator(ValidatorBase):
         )
 
     def interpret(self, value) -> bool:
-        self.duplicate_cnt = int(value)
-        return self.duplicate_cnt == 0
+        if isinstance(value, pd.DataFrame):
+            dup_cnt = int(value.iloc[0, 0]) if not value.empty else 0
+        else:
+            dup_cnt = int(value or 0)
+        self.duplicate_cnt = dup_cnt
+        return dup_cnt == 0
 
 
 class PrimaryKeyUniquenessValidator(ValidatorBase):
@@ -146,5 +150,9 @@ class PrimaryKeyUniquenessValidator(ValidatorBase):
         return exp.select(diff).from_(table)
 
     def interpret(self, value) -> bool:
-        self.duplicate_cnt = int(value)
-        return self.duplicate_cnt == 0
+        if isinstance(value, pd.DataFrame):
+            dup_cnt = int(value.iloc[0, 0]) if not value.empty else 0
+        else:
+            dup_cnt = int(value or 0)
+        self.duplicate_cnt = dup_cnt
+        return dup_cnt == 0


### PR DESCRIPTION
## Summary
- add `SqlErrorRowsValidator` for custom SQL error checks
- allow SqlErrorRows entries in expectation config
- send whole DataFrame to custom validators
- support DataFrame input in duplicate/PK validators
- document custom rule usage
- test new validator and runner integration

## Testing
- `ruff check src/expectations/runner.py src/expectations/validators/table.py src/expectations/config/expectation.py src/expectations/validators/custom.py tests/test_sql_error_rows.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e20072c8832ab46e95ef5b00ab3c