### PR TITLE
Implement FileEngine using DuckDB

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -12,3 +12,22 @@ You can supply your own SQL and have the runner fail when that query returns row
 ```
 
 The validator will attach `error_row_count` and a sample of rows to the validation result.
+
+## Validating Files Directly
+
+The `FileEngine` exposes one or more files as a regular SQL table backed by DuckDB.
+Create the engine with a file path (globs allowed) and a table name, then run validators
+like you would against any database table.
+
+```python
+from src.expectations.engines.file import FileEngine
+from src.expectations.runner import ValidationRunner
+from src.expectations.validators.column import ColumnNotNull
+
+eng = FileEngine("/data/myfile.csv", table="data")
+runner = ValidationRunner({"file": eng})
+results = runner.run([("file", "data", ColumnNotNull(column="id"))])
+```
+
+Wildcards such as `"/data/*.parquet"` combine many files. DuckDB scans the files lazily,
+so only the columns required by each validator are read into memory.

--- a/src/expectations/engines/__init__.py
+++ b/src/expectations/engines/__init__.py
@@ -1,0 +1,6 @@
+"""Execution engine implementations."""
+
+from .duckdb import DuckDBEngine
+from .file import FileEngine
+
+__all__ = ["DuckDBEngine", "FileEngine"]

--- a/src/expectations/engines/file.py
+++ b/src/expectations/engines/file.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import contextlib
+import glob
+import os
+from pathlib import Path
+from typing import List, Sequence
+
+import pandas as pd
+from sqlglot import exp
+
+from .base import BaseEngine
+from .duckdb import DuckDBEngine
+
+
+class FileEngine(BaseEngine):
+    """Expose one or more data files as a SQL table via DuckDB."""
+
+    def __init__(self, path: str | Path, *, table: str = "t", database: str | Path = ":memory:"):
+        self.path = str(path)
+        self.table = table
+        self._duck = DuckDBEngine(database)
+        # Register view pointing to the file path or glob
+        quoted_path = self.path.replace("'", "''")
+        self._duck.run_sql(f"CREATE VIEW {self.table} AS SELECT * FROM '{quoted_path}'")
+        self._dialect = self._duck.get_dialect()
+        self.file_metadata = self._collect_metadata()
+
+    def _collect_metadata(self):
+        meta = []
+        for p in glob.glob(self.path):
+            try:
+                st = os.stat(p)
+                meta.append({
+                    "path": os.path.abspath(p),
+                    "size": st.st_size,
+                    "modified": st.st_mtime,
+                })
+            except OSError:
+                continue
+        return meta
+
+    # ------------------------------------------------------------------ #
+    # BaseEngine interface                                               #
+    # ------------------------------------------------------------------ #
+    def run_sql(self, sql: str | exp.Expression) -> pd.DataFrame:
+        return self._duck.run_sql(sql)
+
+    def run_many(self, sql_statements: Sequence[str | exp.Expression]):
+        return self._duck.run_many(sql_statements)
+
+    def list_columns(self, table: str) -> List[str]:
+        return self._duck.list_columns(table)
+
+    def get_dialect(self) -> str:
+        return self._dialect
+
+    def close(self) -> None:
+        with contextlib.suppress(Exception):
+            self._duck.run_sql(f"DROP VIEW IF EXISTS {self.table}")
+        self._duck.close()
+
+    # ------------------------------------------------------------------ #
+    # Repr                                                               #
+    # ------------------------------------------------------------------ #
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<FileEngine path={self.path!r} table={self.table!r}>"

--- a/tests/test_file_engine.py
+++ b/tests/test_file_engine.py
@@ -1,0 +1,38 @@
+import pandas as pd
+
+from src.expectations.engines.file import FileEngine
+
+
+def test_file_engine_csv(tmp_path):
+    path = tmp_path / "data.csv"
+    pd.DataFrame({"a": [1, 2], "b": [3, 4]}).to_csv(path, index=False)
+
+    eng = FileEngine(path, table="t")
+    cols = set(eng.list_columns("t"))
+    assert cols == {"a", "b"}
+    df = eng.run_sql("SELECT COUNT(*) AS c FROM t")
+    assert df.iloc[0]["c"] == 2
+    eng.close()
+
+
+def test_file_engine_glob(tmp_path):
+    for i in range(2):
+        pd.DataFrame({"a": [i]}).to_csv(tmp_path / f"f{i}.csv", index=False)
+
+    eng = FileEngine(str(tmp_path / "f*.csv"), table="t")
+    df = eng.run_sql("SELECT COUNT(*) AS c FROM t")
+    assert df.iloc[0]["c"] == 2
+    eng.close()
+
+
+def test_file_engine_cleanup(tmp_path):
+    path = tmp_path / "data.csv"
+    pd.DataFrame({"a": [1]}).to_csv(path, index=False)
+
+    eng = FileEngine(path, table="t")
+    eng.close()
+
+    eng2 = FileEngine(path, table="t")
+    df = eng2.run_sql("SELECT COUNT(*) AS c FROM t")
+    assert df.iloc[0]["c"] == 1
+    eng2.close()


### PR DESCRIPTION
## Summary
- add `FileEngine` to expose local files as SQL tables via DuckDB
- export new engine from the engines package
- document how to validate files directly
- add tests covering CSV loading, glob patterns and cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68837826da60832a92bfaa9fe36c7f5c