### PR TITLE
Improve validator test coverage

### DIFF
--- a/tests/test_batch_builder.py
+++ b/tests/test_batch_builder.py
@@ -26,3 +26,17 @@ def test_sql_compiles_and_runs():
     sql = builder.sql()
     df = eng.run_sql(sql)
     assert set(df.columns) == {"rc", "dc"}
+
+def test_apply_filter_generates_case_sum():
+    req = MetricRequest(column='*', metric='row_cnt', alias='rc', filter_sql='a > 1')
+    builder = MetricBatchBuilder(table='t', requests=[req], dialect='duckdb')
+    sql = builder.sql()
+    assert "CASE WHEN a > 1" in sql
+    assert "SUM" in sql
+
+    req2 = MetricRequest(column='a', metric='max', alias='mx', filter_sql='b < 5')
+    builder2 = MetricBatchBuilder(table='t', requests=[req2], dialect='duckdb')
+    sql2 = builder2.sql()
+    assert "CASE WHEN b < 5" in sql2
+    assert "MAX(a)" in sql2
+

--- a/tests/test_integration_suite.py
+++ b/tests/test_integration_suite.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import sys
+from src.expectations.engines.duckdb import DuckDBEngine
+from src.expectations.runner import ValidationRunner
+from src.expectations.config.expectation import ExpectationSuiteConfig
+from src.expectations.validators.custom import SqlErrorRowsValidator
+from src.expectations.validators.table import RowCountValidator, DuplicateRowValidator
+
+
+def test_suite_execution_with_multiple_validations(tmp_path):
+    eng = DuckDBEngine()
+    df = pd.DataFrame({"a": [1, 2, 3, 3], "b": [1, 2, 2, 4]})
+    eng.register_dataframe("t", df)
+    yaml_content = """
+suite_name: demo_suite
+engine: duck
+table: t
+expectations:
+  - expectation_type: RowCountValidator
+    where: "a >= 2"
+    kwargs:
+      min_rows: 3
+  - expectation_type: RowCountValidator
+    where: "a = 1"
+    kwargs:
+      max_rows: 0
+  - expectation_type: DuplicateRowValidator
+    kwargs:
+      key_columns: [a]
+  - expectation_type: SqlErrorRows
+    sql: SELECT * FROM t WHERE a < 0
+"""
+    path = tmp_path / "suite.yml"
+    path.write_text(yaml_content)
+
+    sys.modules.setdefault("validator.validators.custom", sys.modules[SqlErrorRowsValidator.__module__])
+    sys.modules.setdefault("validator.validators.table", sys.modules[RowCountValidator.__module__])
+
+    cfg = ExpectationSuiteConfig.from_yaml(path)
+    runner = ValidationRunner({"duck": eng})
+    results = runner.run(cfg.build_validators())
+    statuses = [r.success for r in results]
+    assert statuses == [True, False, False, True]
+    assert results[0].filter_sql == "a >= 2"
+
+


### PR DESCRIPTION
## Summary
- add coverage for MetricBatchBuilder filtering logic
- test row count validators with where clauses
- add integration test covering multiple validations in a suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68841a99e9bc832ab1a1c57068924ce6