### PR TITLE
Add tests for expectation loader and metric helper

### DIFF
--- a/tests/test_expectation_suite.py
+++ b/tests/test_expectation_suite.py
@@ -1,5 +1,6 @@
 import json
 import tempfile
+import pytest
 
 from src.expectations.config.expectation import ExpectationSuiteConfig
 from src.expectations.validators.column import ColumnNotNull
@@ -55,3 +56,52 @@ expectations:
     assert len(validators) == 1
     _, _, v = validators[0]
     assert isinstance(v, ColumnNotNull)
+
+
+def test_from_file_yaml_and_json(tmp_path):
+    yaml_content = """
+suite_name: s
+engine: duck
+table: t
+expectations:
+  - expectation_type: ColumnNotNull
+    column: a
+"""
+    yml = tmp_path / "suite.yml"
+    yml.write_text(yaml_content)
+    cfg_yaml = ExpectationSuiteConfig.from_file(yml)
+    assert isinstance(cfg_yaml, ExpectationSuiteConfig)
+
+    data = {
+        "suite_name": "s",
+        "engine": "duck",
+        "table": "t",
+        "expectations": [{"expectation_type": "ColumnNotNull", "column": "a"}],
+    }
+    js = tmp_path / "suite.json"
+    js.write_text(json.dumps(data))
+    cfg_json = ExpectationSuiteConfig.from_file(js)
+    assert isinstance(cfg_json, ExpectationSuiteConfig)
+
+
+def test_from_file_unknown_extension(tmp_path):
+    path = tmp_path / "suite.txt"
+    path.write_text("invalid")
+    with pytest.raises(ValueError):
+        ExpectationSuiteConfig.from_file(path)
+
+
+from src.expectations.config.expectation import _resolve_validator_class
+from src.expectations.validators.table import RowCountValidator
+
+
+def test_resolve_validator_class(monkeypatch):
+    sys.modules.setdefault("validator.validators.column", column_mod)
+    cls = _resolve_validator_class("ColumnNotNull")
+    assert cls is ColumnNotNull
+    cls2 = _resolve_validator_class(
+        "src.expectations.validators.table.RowCountValidator"
+    )
+    assert cls2 is RowCountValidator
+    with pytest.raises(AttributeError):
+        _resolve_validator_class("Nope")

--- a/tests/test_metric_builders.py
+++ b/tests/test_metric_builders.py
@@ -51,3 +51,15 @@ def test_extra_metrics():
     assert df.iloc[0]["nn"] == 2
     assert df.iloc[0]["avg"] == approx(1.5)
     assert df.iloc[0]["sd"] == approx((0.5) ** 0.5)
+
+
+def test_pct_where_builder(tmp_path):
+    eng = DuckDBEngine()
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [1, 0, 1]})
+    eng.register_dataframe("t", df)
+    from src.expectations.metrics.registry import pct_where
+
+    builder = pct_where("b = 1")
+    expr = builder("a")
+    val = _run_expr(eng, "t", expr)
+    assert val == approx(2 / 3)


### PR DESCRIPTION
## Summary
- test ExpectationSuiteConfig.from_file for yaml/json and bad extension
- test _resolve_validator_class resolution paths
- test pct_where metric helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688438892114832aac4a708779fe9f33