### PR TITLE
Add DuckDB persistence layer

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -52,5 +52,23 @@ suites:
     table: orders
     expectations:
       - expectation_type: ColumnNotNull
-        column: order_id
+          column: order_id
+  ```
+
+## Persisting Validation Results
+
+Validation results can be stored for later analysis using pluggable stores.
+The `DuckDBResultStore` writes run metadata and results into a DuckDB
+database:
+
+```python
+from src.expectations.engines.duckdb import DuckDBEngine
+from src.expectations.store import DuckDBResultStore
+from src.expectations.runner import ValidationRunner
+
+engine = DuckDBEngine("results.db")
+store = DuckDBResultStore(engine)
+runner = ValidationRunner({"duck": DuckDBEngine()})
+results = runner.run(bindings)
+store.persist_run(RunMetadata(suite_name="demo"), results)
 ```

--- a/src/expectations/engines/duckdb.py
+++ b/src/expectations/engines/duckdb.py
@@ -113,5 +113,6 @@ class DuckDBEngine(BaseEngine):
         self._conn.register(name, df)
 
     def __repr__(self) -> str:  # pragma: no cover
-        loc = ":memory:" if self._conn.database_name == ":memory:" else Path(self._conn.database_name).name
+        db_name = getattr(self._conn, "database_name", ":memory:")
+        loc = ":memory:" if db_name == ":memory:" else Path(db_name).name
         return f"<DuckDBEngine db={loc!r}>"

--- a/src/expectations/store/__init__.py
+++ b/src/expectations/store/__init__.py
@@ -1,0 +1,4 @@
+from .base import BaseResultStore
+from .duckdb import DuckDBResultStore
+
+__all__ = ["BaseResultStore", "DuckDBResultStore"]

--- a/src/expectations/store/base.py
+++ b/src/expectations/store/base.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+from src.expectations.result_model import RunMetadata, ValidationResult
+
+
+class BaseResultStore(ABC):
+    """Abstract interface for persistence backends."""
+
+    @abstractmethod
+    def persist_run(self, run: RunMetadata, results: Sequence[ValidationResult]) -> None:
+        """Persist a run and all its validation results."""
+        raise NotImplementedError

--- a/tests/test_result_store.py
+++ b/tests/test_result_store.py
@@ -1,0 +1,39 @@
+import pandas as pd
+
+from src.expectations.result_model import RunMetadata, ValidationResult
+from src.expectations.store import DuckDBResultStore
+from src.expectations.engines.duckdb import DuckDBEngine
+
+
+def test_duckdb_store_persist(tmp_path):
+    db = tmp_path / "res.db"
+    if db.exists():
+        db.unlink()
+    engine = DuckDBEngine(db)
+    store = DuckDBResultStore(engine)
+
+    # ensure clean tables if they already exist
+    store.connection.execute("DELETE FROM runs")
+    store.connection.execute("DELETE FROM results")
+
+    run = RunMetadata(suite_name="suite1")
+    results = [
+        ValidationResult(
+            run_id=run.run_id,
+            validator="ColumnNotNull",
+            table="t",
+            column="a",
+            metric="null_pct",
+            success=True,
+            value=0.0,
+        )
+    ]
+
+    store.persist_run(run, results)
+
+    df_runs = store.connection.execute("SELECT * FROM runs").fetchdf()
+    df_results = store.connection.execute("SELECT * FROM results").fetchdf()
+
+    assert len(df_runs) == 1
+    assert len(df_results) == 1
+    assert bool(df_results.loc[0, "success"]) is True


### PR DESCRIPTION
## Summary
- add generic `BaseResultStore` interface
- implement `DuckDBResultStore` for persisting results
- test DuckDB persistence
- document how to persist validation results
- use `DuckDBEngine` in `DuckDBResultStore`

## Testing
- `pytest tests/test_result_store.py::test_duckdb_store_persist -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884c1f74498832a8f3306e34fc27350