### PR TITLE
Fix DuckDBResultStore initializer

### DIFF
--- a/src/expectations/store/duckdb.py
+++ b/src/expectations/store/duckdb.py
@@ -14,7 +14,8 @@ from src.expectations.engines.duckdb import DuckDBEngine
 class DuckDBResultStore(BaseResultStore):
     """Persist results into a DuckDB database using :class:`DuckDBEngine`."""
 
-    def __init__(self, database: str | Path = ":memory:", *, engine: Optional[DuckDBEngine] = None):
+    def __init__(self, engine: Optional[DuckDBEngine] = None, *, database: str | Path = ":memory:"):
+        """Create a result store backed by *engine* or a new DuckDBEngine."""
         self._engine = engine or DuckDBEngine(database)
         self._init_schema()
 


### PR DESCRIPTION
## Summary
- fix DuckDBResultStore initializer so first argument can be an engine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885657b6db8832aa8ba19e9075a8a0d