### PR TITLE
Add SLA persistence

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -22,6 +22,7 @@ like you would against any database table.
 ```python
 from src.expectations.engines.file import FileEngine
 from src.expectations.runner import ValidationRunner
+from src.expectations.config.expectation import SLAConfig
 from src.expectations.validators.column import ColumnNotNull
 
 eng = FileEngine("/data/myfile.csv", table="data")
@@ -70,5 +71,7 @@ engine = DuckDBEngine("results.db")
 store = DuckDBResultStore(engine)
 runner = ValidationRunner({"duck": DuckDBEngine()})
 results = runner.run(bindings)
-store.persist_run(RunMetadata(suite_name="demo"), results)
+# persist results with optional SLA configuration
+sla_cfg = SLAConfig(sla_name="nightly", suites=[])
+store.persist_run(RunMetadata(suite_name="demo", sla_name="nightly"), results, sla_cfg)
 ```

--- a/src/expectations/result_model.py
+++ b/src/expectations/result_model.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, Field
 class RunMetadata(BaseModel):
     run_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
     suite_name: str
+    sla_name: Optional[str] = None
     started_at: datetime = Field(default_factory=datetime.utcnow)
     finished_at: Optional[datetime] = None
 

--- a/src/expectations/store/base.py
+++ b/src/expectations/store/base.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Sequence
 
+from src.expectations.config.expectation import SLAConfig
+
 from src.expectations.result_model import RunMetadata, ValidationResult
 
 
@@ -10,6 +12,14 @@ class BaseResultStore(ABC):
     """Abstract interface for persistence backends."""
 
     @abstractmethod
-    def persist_run(self, run: RunMetadata, results: Sequence[ValidationResult]) -> None:
-        """Persist a run and all its validation results."""
+    def persist_run(
+        self,
+        run: RunMetadata,
+        results: Sequence[ValidationResult],
+        sla_config: "SLAConfig | None" = None,
+    ) -> None:
+        """Persist a run and all its validation results.
+
+        ``sla_config`` is stored when provided and ``run.sla_name`` is set.
+        """
         raise NotImplementedError

--- a/tests/test_result_store.py
+++ b/tests/test_result_store.py
@@ -37,3 +37,44 @@ def test_duckdb_store_persist(tmp_path):
     assert len(df_runs) == 1
     assert len(df_results) == 1
     assert bool(df_results.loc[0, "success"]) is True
+
+
+def test_duckdb_store_persist_sla(tmp_path):
+    db = tmp_path / "res.db"
+    if db.exists():
+        db.unlink()
+    engine = DuckDBEngine(db)
+    store = DuckDBResultStore(engine)
+
+    store.connection.execute("DELETE FROM runs")
+    store.connection.execute("DELETE FROM results")
+    store.connection.execute("DELETE FROM slas")
+
+    run = RunMetadata(suite_name="suite1", sla_name="sla1")
+    results = [
+        ValidationResult(
+            run_id=run.run_id,
+            validator="ColumnNotNull",
+            table="t",
+            column="a",
+            metric="null_pct",
+            success=True,
+            value=0.0,
+        )
+    ]
+
+    from src.expectations.config.expectation import SLAConfig, ExpectationSuiteConfig
+
+    sla_cfg = SLAConfig(
+        sla_name="sla1",
+        suites=[ExpectationSuiteConfig(suite_name="suite1", engine="duck", table="t", expectations=[])]
+    )
+
+    store.persist_run(run, results, sla_cfg)
+
+    df_runs = store.connection.execute("SELECT * FROM runs").fetchdf()
+    df_slas = store.connection.execute("SELECT * FROM slas").fetchdf()
+
+    assert len(df_runs) == 1
+    assert df_runs.loc[0, "sla_name"] == "sla1"
+    assert len(df_slas) == 1


### PR DESCRIPTION
## Summary
- add optional `sla_name` to `RunMetadata`
- extend `BaseResultStore.persist_run` to store SLA info
- add DuckDB `slas` table and reference from `runs`
- document SLA persistence usage
- test storing SLA configs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885676434b4832ab099f746ff6cf6c1