### PR TITLE
Update validator paths

### DIFF
--- a/src/expectations/config/expectation.py
+++ b/src/expectations/config/expectation.py
@@ -1,6 +1,6 @@
 """
-validator.config.expectation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+src.expectations.config.expectation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Pydantic models that describe an *expectation suite* and a helper that
 translates it into concrete `ValidatorBase` instances.
@@ -156,12 +156,12 @@ def _resolve_validator_class(name: str) -> type[ValidatorBase]:
     Resolve *name* (e.g. "ColumnNotNull") to an actual class.
 
     Strategy:
-      1. Look in `validator.validators` sub-modules already imported.
+      1. Look in `src.expectations.validators` sub-modules already imported.
       2. Fallback to dynamic import.
     """
     # optimistic: already in sys.modules
     for mod_name in list(sys.modules):
-        if mod_name.startswith("validator.validators."):
+        if mod_name.startswith("src.expectations.validators."):
             mod = sys.modules[mod_name]
             if hasattr(mod, name):
                 return getattr(mod, name)
@@ -170,7 +170,7 @@ def _resolve_validator_class(name: str) -> type[ValidatorBase]:
     parts = name.split(".")
     if len(parts) == 1:
         # assume it's in the default column module
-        mod = import_module("validator.validators.column")
+        mod = import_module("src.expectations.validators.column")
         return getattr(mod, name)
     *pkg, cls_name = parts
     mod = import_module(".".join(pkg))

--- a/src/expectations/engines/base.py
+++ b/src/expectations/engines/base.py
@@ -1,6 +1,6 @@
 """
-validator.engines.base
-~~~~~~~~~~~~~~~~~~~~~~
+src.expectations.engines.base
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Minimal contract every execution engine must satisfy.
 Keeps the API surface tiny: new back-ends only need to provide *three*

--- a/src/expectations/engines/duckdb.py
+++ b/src/expectations/engines/duckdb.py
@@ -1,8 +1,8 @@
 """
-validator.engines.duckdb
-~~~~~~~~~~~~~~~~~~~~~~~~
+src.expectations.engines.duckdb
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Concrete implementation of :class:`validator.engines.base.BaseEngine`
+Concrete implementation of :class:`src.expectations.engines.base.BaseEngine`
 for an embedded DuckDB database.  Perfect for unit-tests, local
 experimentation, and small-scale production jobs.
 

--- a/src/expectations/metrics/batch_builder.py
+++ b/src/expectations/metrics/batch_builder.py
@@ -1,6 +1,6 @@
 """
-validator.metrics.batch_builder
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+src.expectations.metrics.batch_builder
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Creates **one** SELECT statement that evaluates *n* metric expressions
 and aliases them with the validator's unique runtime IDs.  Dialect

--- a/src/expectations/metrics/registry.py
+++ b/src/expectations/metrics/registry.py
@@ -1,6 +1,6 @@
 """
-validator.metrics.registry
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+src.expectations.metrics.registry
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Global **metric registry** mapping a *metric key* (e.g. ``"null_pct"``)
 to a *builder* – a callable that receives a **column name** and returns a

--- a/src/expectations/result_model.py
+++ b/src/expectations/result_model.py
@@ -1,6 +1,6 @@
 """
-validator.result_models
-~~~~~~~~~~~~~~~~~~~~~~~
+src.expectations.result_model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Typed artefacts passed from runner to downstream stores / reporters.
 """

--- a/src/expectations/runner.py
+++ b/src/expectations/runner.py
@@ -1,6 +1,6 @@
 """
-validator.runner
-~~~~~~~~~~~~~~~~
+src.expectations.runner
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Single entry-point that executes both *metric* and *custom* validators.
 """

--- a/src/expectations/validators/base.py
+++ b/src/expectations/validators/base.py
@@ -1,6 +1,6 @@
 """
-validator.validators.base
-~~~~~~~~~~~~~~~~~~~~~~~~~
+src.expectations.validators.base
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Common parent for all validators.  Two *kinds* are supported:
 

--- a/src/expectations/validators/column.py
+++ b/src/expectations/validators/column.py
@@ -1,6 +1,6 @@
 """
-validator.validators.column
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+src.expectations.validators.column
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Ready-to-use **column-level** validators that integrate with the new
 batch-execution architecture.
@@ -8,7 +8,7 @@ batch-execution architecture.
 * All classes inherit :class:`ColumnMetricValidator` which implements
   the boilerplate for metric-type validators.
 * Each validator registers (or re-uses) a metric key in
-  ``validator.metrics.registry`` and provides `interpret()` logic.
+  ``src.expectations.metrics.registry`` and provides `interpret()` logic.
 
 New metrics added here:
     - ``min``      → MIN(column)

--- a/src/expectations/validators/table.py
+++ b/src/expectations/validators/table.py
@@ -1,6 +1,6 @@
 """
-validator.validators.table
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+src.expectations.validators.table
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Table-level validators.
 

--- a/tests/test_expectation_suite.py
+++ b/tests/test_expectation_suite.py
@@ -51,7 +51,6 @@ expectations:
     path = tmp_path / "suite.yml"
     path.write_text(yaml_content)
     cfg = ExpectationSuiteConfig.from_yaml(path)
-    sys.modules.setdefault("validator.validators.column", column_mod)
     validators = list(cfg.build_validators())
     assert len(validators) == 1
     _, _, v = validators[0]
@@ -96,7 +95,6 @@ from src.expectations.validators.table import RowCountValidator
 
 
 def test_resolve_validator_class(monkeypatch):
-    sys.modules.setdefault("validator.validators.column", column_mod)
     cls = _resolve_validator_class("ColumnNotNull")
     assert cls is ColumnNotNull
     cls2 = _resolve_validator_class(

--- a/tests/test_integration_suite.py
+++ b/tests/test_integration_suite.py
@@ -33,9 +33,6 @@ expectations:
     path = tmp_path / "suite.yml"
     path.write_text(yaml_content)
 
-    sys.modules.setdefault("validator.validators.custom", sys.modules[SqlErrorRowsValidator.__module__])
-    sys.modules.setdefault("validator.validators.table", sys.modules[RowCountValidator.__module__])
-
     cfg = ExpectationSuiteConfig.from_yaml(path)
     runner = ValidationRunner({"duck": eng})
     results = runner.run(cfg.build_validators())

--- a/tests/test_sla_config.py
+++ b/tests/test_sla_config.py
@@ -36,7 +36,6 @@ def test_sla_build_validators(tmp_path):
     path = tmp_path / "sla.yml"
     path.write_text(_sample_yaml())
     cfg = SLAConfig.from_yaml(path)
-    sys.modules.setdefault("validator.validators.column", column_mod)
     validators = list(cfg.build_validators())
     assert len(validators) == 2
     assert isinstance(validators[0][2], ColumnNotNull)

--- a/tests/test_sql_error_rows.py
+++ b/tests/test_sql_error_rows.py
@@ -47,8 +47,6 @@ expectations:
 """
     path = tmp_path / "suite.yml"
     path.write_text(yaml_content)
-    sys.modules.setdefault("validator.validators.custom", sys.modules[SqlErrorRowsValidator.__module__])
-    sys.modules.setdefault("validator.validators.column", sys.modules[ColumnNotNull.__module__])
     cfg = ExpectationSuiteConfig.from_yaml(path)
     runner = ValidationRunner({"duck": eng})
     results = runner.run(cfg.build_validators())


### PR DESCRIPTION
## Summary
- look for validators under `src.expectations.validators`
- drop deprecated `validator.validators` aliases in tests
- refresh module headers with the new package path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856ae7c9ec832a8d67285abd71a1c4