### PR TITLE
Add run_id parameter to ValidationRunner

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -23,11 +23,13 @@ like you would against any database table.
 from src.expectations.engines.file import FileEngine
 from src.expectations.runner import ValidationRunner
 from src.expectations.config.expectation import SLAConfig
+from src.expectations.result_model import RunMetadata
 from src.expectations.validators.column import ColumnNotNull
 
 eng = FileEngine("/data/myfile.csv", table="data")
 runner = ValidationRunner({"file": eng})
-results = runner.run([("file", "data", ColumnNotNull(column="id"))])
+run = RunMetadata(suite_name="demo")
+results = runner.run([("file", "data", ColumnNotNull(column="id"))], run_id=run.run_id)
 ```
 
 Wildcards such as `"/data/*.parquet"` combine many files. DuckDB scans the files lazily,
@@ -66,12 +68,14 @@ database:
 from src.expectations.engines.duckdb import DuckDBEngine
 from src.expectations.store import DuckDBResultStore
 from src.expectations.runner import ValidationRunner
+from src.expectations.result_model import RunMetadata
 
 engine = DuckDBEngine("results.db")
 store = DuckDBResultStore(engine)
 runner = ValidationRunner({"duck": DuckDBEngine()})
-results = runner.run(bindings)
+run = RunMetadata(suite_name="demo", sla_name="nightly")
+results = runner.run(bindings, run_id=run.run_id)
 # persist results with optional SLA configuration
 sla_cfg = SLAConfig(sla_name="nightly", suites=[])
-store.persist_run(RunMetadata(suite_name="demo", sla_name="nightly"), results, sla_cfg)
+store.persist_run(run, results, sla_cfg)
 ```

--- a/test.py
+++ b/test.py
@@ -2,6 +2,7 @@ import pandas as pd
 from src.expectations.engines.duckdb import DuckDBEngine
 from src.expectations.validators.column import ColumnNotNull
 from src.expectations.runner import ValidationRunner
+from src.expectations.result_model import RunMetadata
 
 # 1) set-up a tiny table
 eng = DuckDBEngine()
@@ -10,4 +11,5 @@ eng.register_dataframe("t", pd.DataFrame({"a": [1, 2, None], "b": [1, 2, 3]}))
 # 2) run a ColumnNotNull check on column 'b'
 bindings = [("duck", "t", ColumnNotNull(column="b"))]
 runner   = ValidationRunner({"duck": eng})
-print(runner.run(bindings))
+run = RunMetadata(suite_name="demo")
+print(runner.run(bindings, run_id=run.run_id))

--- a/tests/test_column_validators.py
+++ b/tests/test_column_validators.py
@@ -18,7 +18,7 @@ from src.expectations.validators.table import RowCountValidator
 
 def _run(eng, table, validator):
     runner = ValidationRunner({"duck": eng})
-    return runner.run([("duck", table, validator)])[0]
+    return runner.run([("duck", table, validator)], run_id="test")[0]
 
 
 def test_column_not_null_pass_fail():

--- a/tests/test_integration_suite.py
+++ b/tests/test_integration_suite.py
@@ -35,7 +35,7 @@ expectations:
 
     cfg = ExpectationSuiteConfig.from_yaml(path)
     runner = ValidationRunner({"duck": eng})
-    results = runner.run(cfg.build_validators())
+    results = runner.run(cfg.build_validators(), run_id="test")
     statuses = [r.success for r in results]
     assert statuses == [True, False, False, True]
     assert results[0].filter_sql == "a >= 2"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -38,7 +38,7 @@ def test_metric_grouping(monkeypatch):
         ("duck", "t", ColumnNotNull(column="a")),
         ("duck", "t", ColumnNullPct(column="a", max_null_pct=1.0)),
     ]
-    runner.run(bindings)
+    runner.run(bindings, run_id="test")
     assert len(calls) == 1
 
 
@@ -59,7 +59,7 @@ def test_metric_and_custom_calls(monkeypatch):
         ("duck", "t", ColumnNotNull(column="a")),
         ("duck", "t", DuplicateRowValidator(key_columns=["a"])),
     ]
-    runner.run(bindings)
+    runner.run(bindings, run_id="test")
     assert len(calls) == 2
 
 
@@ -68,6 +68,6 @@ def test_error_propagation(monkeypatch):
     eng.register_dataframe("t", pd.DataFrame({"a": [1]}))
 
     runner = ValidationRunner({"duck": eng})
-    res = runner.run([("duck", "t", FaultyValidator())])[0]
+    res = runner.run([("duck", "t", FaultyValidator())], run_id="test")[0]
     assert res.success is False
     assert "error" in res.details

--- a/tests/test_sql_error_rows.py
+++ b/tests/test_sql_error_rows.py
@@ -10,7 +10,7 @@ from src.expectations.config.expectation import ExpectationSuiteConfig
 
 def _run(eng, table, validator):
     runner = ValidationRunner({"duck": eng})
-    return runner.run([("duck", table, validator)])[0]
+    return runner.run([("duck", table, validator)], run_id="test")[0]
 
 
 def test_sql_error_rows_pass():
@@ -49,6 +49,6 @@ expectations:
     path.write_text(yaml_content)
     cfg = ExpectationSuiteConfig.from_yaml(path)
     runner = ValidationRunner({"duck": eng})
-    results = runner.run(cfg.build_validators())
+    results = runner.run(cfg.build_validators(), run_id="test")
     assert len(results) == 2
 

--- a/tests/test_table_validators.py
+++ b/tests/test_table_validators.py
@@ -11,7 +11,7 @@ from src.expectations.validators.table import (
 
 def _run(eng, table, validator):
     runner = ValidationRunner({"duck": eng})
-    return runner.run([("duck", table, validator)])[0]
+    return runner.run([("duck", table, validator)], run_id="test")[0]
 
 
 def test_row_count_bounds():


### PR DESCRIPTION
## Summary
- extend `ValidationRunner.run` with a required `run_id` parameter
- propagate run identifiers to every `ValidationResult`
- update examples and docs to show how to provide a run id
- adjust tests for the new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856ccfb4a0832aa59b38a51310c971