### PR TITLE
Replace eval usage in ColumnDistinctCount

### DIFF
--- a/src/expectations/validators/column.py
+++ b/src/expectations/validators/column.py
@@ -117,7 +117,16 @@ class ColumnDistinctCount(ColumnMetricValidator):
 
     def interpret(self, value) -> bool:
         self.distinct_cnt = int(value)
-        return eval(f"{self.distinct_cnt} {self.op} {self.expected}")  # noqa: S307
+        if self.op == "==":
+            return self.distinct_cnt == self.expected
+        if self.op == ">=":
+            return self.distinct_cnt >= self.expected
+        if self.op == "<=":
+            return self.distinct_cnt <= self.expected
+        if self.op == ">":
+            return self.distinct_cnt > self.expected
+        # self.op must be "<" by constructor validation
+        return self.distinct_cnt < self.expected
 
 
 class ColumnMin(ColumnMetricValidator):

--- a/tests/test_column_validators.py
+++ b/tests/test_column_validators.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from src.expectations.engines.duckdb import DuckDBEngine
 from src.expectations.runner import ValidationRunner
@@ -54,6 +55,24 @@ def test_column_distinct_count_ops():
     for op, expected in cases:
         res = _run(eng, "t", ColumnDistinctCount(column="a", expected=3, op=op))
         assert res.success is expected
+
+
+@pytest.mark.parametrize(
+    "op, expected",
+    [
+        ("==", True),
+        (">=", True),
+        ("<=", True),
+        (">", False),
+        ("<", False),
+    ],
+)
+def test_column_distinct_count_parametrized(op, expected):
+    eng = DuckDBEngine()
+    df = pd.DataFrame({"a": [1, 1, 2, 3]})
+    eng.register_dataframe("t", df)
+    res = _run(eng, "t", ColumnDistinctCount(column="a", expected=3, op=op))
+    assert res.success is expected
 
 
 def test_column_min_max_strict_vs_inclusive():


### PR DESCRIPTION
## Summary
- drop use of `eval` in `ColumnDistinctCount.interpret`
- add parameterized operator tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856fe25e50832a886976b7b2054617