### PR TITLE
Add requirements and docs

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,5 +1,14 @@
 # Cookbook
 
+## Installation
+
+Install the dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+
 ## Writing Custom Rules
 
 You can supply your own SQL and have the runner fail when that query returns rows.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pandas
+duckdb
+sqlglot
+pydantic
+PyYAML
+pytest


### PR DESCRIPTION
## Summary
- list runtime and test dependencies in `requirements.txt`
- add installation section to the cookbook

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856fe5d5a8832a8e703c469ff09596