### PR TITLE
Add faker data to test utilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sqlglot
 pydantic
 PyYAML
 pytest
+faker

--- a/tests/test_end_to_end_workflow.py
+++ b/tests/test_end_to_end_workflow.py
@@ -1,0 +1,87 @@
+import pandas as pd
+
+from src.expectations.config.expectation import SLAConfig
+from src.expectations.runner import ValidationRunner
+from src.expectations.store import DuckDBResultStore
+from src.expectations.workflow import run_validations
+
+from tests.utils import setup_sample_engine
+
+
+def test_full_end_to_end_workflow(tmp_path):
+    eng = setup_sample_engine()
+
+    sla_yaml = """
+    sla_name: ecommerce
+    suites:
+      - suite_name: orders_suite
+        engine: duck
+        table: orders
+        expectations:
+          - expectation_type: RowCountValidator
+            kwargs:
+              min_rows: 1
+          - expectation_type: ColumnNotNull
+            column: order_id
+          - expectation_type: ColumnMin
+            column: amount
+            kwargs:
+              min_value: 0
+          - expectation_type: DuplicateRowValidator
+            kwargs:
+              key_columns: [order_id]
+          - expectation_type: SqlErrorRows
+            sql: SELECT * FROM orders WHERE amount < 0
+            max_error_rows: 5
+      - suite_name: customers_suite
+        engine: duck
+        table: customers
+        expectations:
+          - expectation_type: PrimaryKeyUniquenessValidator
+            kwargs:
+              key_columns: [customer_id]
+          - expectation_type: ColumnMatchesRegex
+            column: email
+            kwargs:
+              pattern: '^[^@]+@[^@]+\\.[^@]+$'
+          - expectation_type: ColumnNotNull
+            column: email
+          - expectation_type: ColumnDistinctCount
+            column: customer_id
+            kwargs:
+              expected: 3
+              op: '=='
+    """
+    path = tmp_path / "sla.yml"
+    path.write_text(sla_yaml)
+
+    sla_cfg = SLAConfig.from_yaml(path)
+
+    runner = ValidationRunner({"duck": eng})
+    store = DuckDBResultStore(eng)
+
+    store.connection.execute("DELETE FROM runs")
+    store.connection.execute("DELETE FROM results")
+    store.connection.execute("DELETE FROM slas")
+
+    for suite in sla_cfg.suites:
+        run_validations(
+            suite_name=suite.suite_name,
+            bindings=suite.build_validators(),
+            runner=runner,
+            store=store,
+            sla_config=sla_cfg,
+        )
+
+    df_runs = store.connection.execute("SELECT * FROM runs").fetchdf()
+    df_results = store.connection.execute("SELECT * FROM results").fetchdf()
+    df_slas = store.connection.execute("SELECT * FROM slas").fetchdf()
+
+    assert len(df_slas) == 1
+    assert df_slas.loc[0, "sla_name"] == "ecommerce"
+
+    assert len(df_runs) == 2
+    assert set(df_runs["suite_name"]) == {"orders_suite", "customers_suite"}
+
+    assert len(df_results) == 9
+    assert df_results["success"].sum() == 3

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,59 @@
+import pandas as pd
+from faker import Faker
+from src.expectations.engines.duckdb import DuckDBEngine
+
+
+fake = Faker()
+Faker.seed(0)
+
+
+def sample_orders_df() -> pd.DataFrame:
+    """Return a small orders DataFrame with typical issues using Faker."""
+    statuses = ["open", "shipped", "cancelled"]
+    rows = [
+        {
+            "order_id": 1,
+            "customer_id": 1,
+            "amount": fake.pyfloat(min_value=50, max_value=200, right_digits=2),
+            "status": fake.random_element(statuses),
+        },
+        {
+            "order_id": 2,
+            "customer_id": 2,
+            "amount": fake.pyfloat(min_value=100, max_value=300, right_digits=2),
+            "status": fake.random_element(statuses),
+        },
+        {
+            "order_id": 3,
+            "customer_id": 2,
+            "amount": -50,
+            "status": fake.random_element(statuses),
+        },
+        {
+            "order_id": 4,
+            "customer_id": 3,
+            "amount": fake.pyfloat(min_value=100, max_value=400, right_digits=2),
+            "status": fake.random_element(statuses),
+        },
+        {
+            "order_id": 4,
+            "customer_id": 4,
+            "amount": None,
+            "status": fake.random_element(statuses),
+        },
+    ]
+    return pd.DataFrame(rows)
+
+
+def sample_customers_df() -> pd.DataFrame:
+    """Return a small customers DataFrame with duplicates and bad emails using Faker."""
+    emails = [fake.email(), fake.email(), None, "invalid_email"]
+    return pd.DataFrame({"customer_id": [1, 2, 3, 2], "email": emails})
+
+
+def setup_sample_engine() -> DuckDBEngine:
+    """Create a DuckDB engine preloaded with sample tables."""
+    eng = DuckDBEngine()
+    eng.register_dataframe("orders", sample_orders_df())
+    eng.register_dataframe("customers", sample_customers_df())
+    return eng


### PR DESCRIPTION
## Summary
- add `faker` to requirements
- generate sample order and customer data with faker for more realistic tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688574896cb0832ab5ac04f3233d76f1