### PR TITLE
Fix filtering for aggregates

### DIFF
--- a/tests/test_batch_builder.py
+++ b/tests/test_batch_builder.py
@@ -27,16 +27,16 @@ def test_sql_compiles_and_runs():
     df = eng.run_sql(sql)
     assert set(df.columns) == {"rc", "dc"}
 
-def test_apply_filter_generates_case_sum():
-    req = MetricRequest(column='*', metric='row_cnt', alias='rc', filter_sql='a > 1')
-    builder = MetricBatchBuilder(table='t', requests=[req], dialect='duckdb')
+def test_apply_filter_generates_conditional_aggregates():
+    req = MetricRequest(column="*", metric="row_cnt", alias="rc", filter_sql="a > 1")
+    builder = MetricBatchBuilder(table="t", requests=[req], dialect="duckdb")
     sql = builder.sql()
     assert "CASE WHEN a > 1" in sql
-    assert "SUM" in sql
+    assert "SUM(CASE WHEN a > 1 THEN 1 END)" in sql
 
-    req2 = MetricRequest(column='a', metric='max', alias='mx', filter_sql='b < 5')
-    builder2 = MetricBatchBuilder(table='t', requests=[req2], dialect='duckdb')
+    req2 = MetricRequest(column="a", metric="max", alias="mx", filter_sql="b < 5")
+    builder2 = MetricBatchBuilder(table="t", requests=[req2], dialect="duckdb")
     sql2 = builder2.sql()
     assert "CASE WHEN b < 5" in sql2
-    assert "MAX(a)" in sql2
+    assert "MAX(CASE WHEN b < 5 THEN a END)" in sql2
 

--- a/tests/test_column_validators.py
+++ b/tests/test_column_validators.py
@@ -131,6 +131,26 @@ def test_column_greater_equal():
     v = ColumnGreaterEqual(column="b", other_column="a")
     assert _run(eng, "t", v).success is False
 
+
+def test_column_min_where_clause():
+    eng = DuckDBEngine()
+    df = pd.DataFrame({"a": [1, 3], "b": [0, 1]})
+    eng.register_dataframe("t", df)
+    v_pass = ColumnMin(column="a", min_value=3, where="b = 1")
+    assert _run(eng, "t", v_pass).success is True
+    v_fail = ColumnMin(column="a", min_value=2, where="b = 0")
+    assert _run(eng, "t", v_fail).success is False
+
+
+def test_column_max_where_clause():
+    eng = DuckDBEngine()
+    df = pd.DataFrame({"a": [3, 10], "b": [0, 1]})
+    eng.register_dataframe("t", df)
+    v_pass = ColumnMax(column="a", max_value=3, where="b = 0")
+    assert _run(eng, "t", v_pass).success is True
+    v_fail = ColumnMax(column="a", max_value=5, where="b = 1")
+    assert _run(eng, "t", v_fail).success is False
+
 def test_where_clause_filters_rows():
     eng = DuckDBEngine()
     df = pd.DataFrame({"a": [1, None], "b": [0, 1]})


### PR DESCRIPTION
## Summary
- implement smarter conditional aggregation in `MetricBatchBuilder`
- update batch builder test to check new SQL
- add tests for `ColumnMin` and `ColumnMax` when using `where` filters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688589483b80832a8c037eb9aeea8072