### PR TITLE
Add engine and schema metadata

### DIFF
--- a/src/expectations/result_model.py
+++ b/src/expectations/result_model.py
@@ -18,6 +18,8 @@ class RunMetadata(BaseModel):
     run_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
     suite_name: str
     sla_name: Optional[str] = None
+    engine_name: Optional[str] = None
+    schema: Optional[str] = None
     started_at: datetime = Field(default_factory=datetime.utcnow)
     finished_at: Optional[datetime] = None
 
@@ -29,6 +31,8 @@ class ValidationResult(BaseModel):
     run_id: str
     validator: str
     table: str
+    engine_name: Optional[str] = None
+    schema: Optional[str] = None
     column: Optional[str] = None
     metric: Optional[str] = None
     success: bool

--- a/src/expectations/store/duckdb.py
+++ b/src/expectations/store/duckdb.py
@@ -36,6 +36,8 @@ class DuckDBResultStore(BaseResultStore):
                 run_id TEXT PRIMARY KEY,
                 suite_name TEXT,
                 sla_name TEXT REFERENCES slas(sla_name),
+                engine_name TEXT,
+                schema TEXT,
                 started_at TIMESTAMP,
                 finished_at TIMESTAMP
             )
@@ -48,6 +50,8 @@ class DuckDBResultStore(BaseResultStore):
                 validator TEXT,
                 table_name TEXT,
                 column_name TEXT,
+                engine_name TEXT,
+                schema TEXT,
                 metric TEXT,
                 success BOOLEAN,
                 value TEXT,
@@ -73,23 +77,27 @@ class DuckDBResultStore(BaseResultStore):
                 (run.sla_name, json.dumps(sla_config.model_dump())),
             )
         self._engine.connection.execute(
-            "INSERT INTO runs VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO runs VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 run.run_id,
                 run.suite_name,
                 run.sla_name,
+                run.engine_name,
+                run.schema,
                 run.started_at,
                 run.finished_at,
             ),
         )
         for r in results:
             self._engine.connection.execute(
-                "INSERT INTO results VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO results VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     r.run_id,
                     r.validator,
                     r.table,
                     r.column,
+                    r.engine_name,
+                    r.schema,
                     r.metric,
                     r.success,
                     r.value,

--- a/src/expectations/workflow.py
+++ b/src/expectations/workflow.py
@@ -26,11 +26,21 @@ def run_validations(
     ``sla_config`` can be provided when the run is associated with an SLA.
     """
 
+    engine_name = bindings[0][0] if bindings else None
+    schema = None
+    if bindings and "." in bindings[0][1]:
+        schema = bindings[0][1].rsplit(".", 1)[0]
+
     run = RunMetadata(
         suite_name=suite_name,
         sla_name=sla_config.sla_name if sla_config else None,
+        engine_name=engine_name,
+        schema=schema,
     )
     results = runner.run(bindings, run_id=run.run_id)
+    for r in results:
+        r.engine_name = run.engine_name
+        r.schema = run.schema
     run.finished_at = datetime.utcnow()
     store.persist_run(run, results, sla_config)
     return run, results

--- a/tests/test_end_to_end_workflow.py
+++ b/tests/test_end_to_end_workflow.py
@@ -82,6 +82,8 @@ def test_full_end_to_end_workflow(tmp_path):
 
     assert len(df_runs) == 2
     assert set(df_runs["suite_name"]) == {"orders_suite", "customers_suite"}
+    assert set(df_runs["engine_name"]) == {"duck"}
 
     assert len(df_results) == 9
+    assert set(df_results["engine_name"]) == {"duck"}
     assert df_results["success"].sum() == 3

--- a/tests/test_result_store.py
+++ b/tests/test_result_store.py
@@ -33,6 +33,8 @@ def test_duckdb_store_persist(tmp_path):
 
     assert len(df_runs) == 1
     assert len(df_results) == 1
+    assert df_runs.loc[0, "engine_name"] == "duck"
+    assert df_results.loc[0, "engine_name"] == "duck"
     assert bool(df_results.loc[0, "success"]) is True
 
 
@@ -69,5 +71,6 @@ def test_duckdb_store_persist_sla(tmp_path):
     df_slas = store.connection.execute("SELECT * FROM slas").fetchdf()
 
     assert len(df_runs) == 1
+    assert df_runs.loc[0, "engine_name"] == "duck"
     assert df_runs.loc[0, "sla_name"] == "sla1"
     assert len(df_slas) == 1


### PR DESCRIPTION
## Summary
- add optional `engine_name` and `schema` fields to metadata models
- store the engine and schema in DuckDB schema
- include engine and schema when running validations
- check the new columns in result store tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858a849860832a97c04b64dc6f6a8b