### PR TITLE
Add statistics module and persistence

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -88,3 +88,27 @@ results = runner.run(bindings, run_id=run.run_id)
 sla_cfg = SLAConfig(sla_name="nightly", suites=[])
 store.persist_run(run, results, sla_cfg)
 ```
+
+## Collecting Table Statistics
+
+`TableStatsCollector` computes basic metrics for every column using the same
+metric builders that power the validators. Statistics can be persisted alongside
+validation results and later queried to derive reasonable thresholds or SLOs.
+
+```python
+from src.expectations.stats import TableStatsCollector
+from src.expectations.store import DuckDBResultStore
+from src.expectations.engines.duckdb import DuckDBEngine
+from src.expectations.result_model import RunMetadata
+
+engine = DuckDBEngine()
+store = DuckDBResultStore(engine)
+collector = TableStatsCollector({"duck": engine})
+
+run = RunMetadata(suite_name="stats_demo")
+stats = collector.collect("duck", "orders", run_id=run.run_id)
+store.persist_stats(run, stats)
+```
+
+Persisted statistics are indexed by engine, schema, table and column which makes
+looking up historical ranges for a given column trivial.

--- a/src/expectations/stats/__init__.py
+++ b/src/expectations/stats/__init__.py
@@ -1,0 +1,97 @@
+"""Collect and persist basic table statistics."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import pandas as pd
+
+from src.expectations.engines.base import BaseEngine
+from src.expectations.metrics.batch_builder import MetricBatchBuilder, MetricRequest
+from pydantic import BaseModel
+
+
+class MetricStat(BaseModel):
+    """Single metric value computed for a table/column."""
+
+    run_id: str
+    table: str
+    column: Optional[str] = None
+    metric: str
+    value: Any
+    engine_name: Optional[str] = None
+    schema: Optional[str] = None
+
+
+class TableStatsCollector:
+    """Compute statistics for all columns of a table."""
+
+    DEFAULT_COLUMN_METRICS: Tuple[str, ...] = ("null_pct", "min", "max")
+    DEFAULT_TABLE_METRICS: Tuple[str, ...] = ("row_cnt",)
+
+    def __init__(self, engine_map: Dict[str, BaseEngine]):
+        self.engine_map = engine_map
+
+    def collect(
+        self,
+        engine_key: str,
+        table: str,
+        *,
+        run_id: str,
+        column_metrics: Sequence[str] | None = None,
+        table_metrics: Sequence[str] | None = None,
+    ) -> List[MetricStat]:
+        """Return statistics for *table* as a list of :class:`MetricStat`."""
+
+        col_metrics = tuple(column_metrics or self.DEFAULT_COLUMN_METRICS)
+        tbl_metrics = tuple(table_metrics or self.DEFAULT_TABLE_METRICS)
+
+        engine = self.engine_map[engine_key]
+        columns = engine.list_columns(table)
+
+        alias_map: Dict[str, Tuple[Optional[str], str]] = {}
+        requests: List[MetricRequest] = []
+
+        idx = 0
+        # table-level metrics
+        for metric in tbl_metrics:
+            alias = f"m{idx}"
+            idx += 1
+            requests.append(MetricRequest(column="*", metric=metric, alias=alias))
+            alias_map[alias] = (None, metric)
+
+        # column metrics
+        for col in columns:
+            for metric in col_metrics:
+                alias = f"m{idx}"
+                idx += 1
+                requests.append(
+                    MetricRequest(column=col, metric=metric, alias=alias)
+                )
+                alias_map[alias] = (col, metric)
+
+        sql = MetricBatchBuilder(
+            table=table, requests=requests, dialect=engine.get_dialect()
+        ).sql()
+        df: pd.DataFrame = engine.run_sql(sql)
+        row = df.iloc[0]
+
+        stats: List[MetricStat] = []
+        schema = None
+        if "." in table:
+            schema = table.rsplit(".", 1)[0]
+        for alias, (col, metric) in alias_map.items():
+            stats.append(
+                MetricStat(
+                    run_id=run_id,
+                    table=table,
+                    column=col,
+                    metric=metric,
+                    value=row[alias],
+                    engine_name=engine_key,
+                    schema=schema,
+                )
+            )
+        return stats
+
+__all__ = ["TableStatsCollector", "MetricStat"]

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+from src.expectations.engines.duckdb import DuckDBEngine
+from src.expectations.stats import TableStatsCollector
+from src.expectations.store import DuckDBResultStore
+from src.expectations.result_model import RunMetadata
+
+
+def test_collect_and_persist_stats(tmp_path):
+    eng = DuckDBEngine()
+    df = pd.DataFrame({"a": [1, 2, None], "b": [5, 6, 7]})
+    eng.register_dataframe("t", df)
+
+    store = DuckDBResultStore(eng)
+    store.connection.execute("DELETE FROM statistics")
+
+    collector = TableStatsCollector({"duck": eng})
+    run = RunMetadata(suite_name="stats")
+    stats = collector.collect("duck", "t", run_id=run.run_id)
+    store.persist_stats(run, stats)
+
+    df_stats = store.connection.execute(
+        "SELECT metric, column_name, value FROM statistics WHERE run_id = ?",
+        (run.run_id,),
+    ).fetchdf()
+
+    assert {"row_cnt", "null_pct", "min", "max"}.issubset(set(df_stats["metric"]))
+    row_cnt = float(df_stats[df_stats["metric"] == "row_cnt"]["value"].iloc[0])
+    assert row_cnt == 3.0


### PR DESCRIPTION
## Summary
- create `TableStatsCollector` to compute column metrics
- add `statistics` table & `persist_stats` method to DuckDBResultStore
- document collecting table statistics
- test stats collection and persistence

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858bcecad8832a9b3a110797f89f8d