### PR TITLE
Fix pyc ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .venv
 __pycache__*
 __pycache__/*
-src/expectations/metrics/__pycache__/registry.cpython-312.pyc
+*.pyc
+# Engine-specific caches
 src/expectations/engines/__pycache__/
+
+# Local IDE configuration
 settings.json


### PR DESCRIPTION
## Summary
- ignore all `.pyc` files instead of one specific path
- keep cache directories ignored and document why `settings.json` is excluded

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a2aa6820832a88f03b2dad34eba8