### PR TITLE
Add concurrency-safe registry and engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Validator
+
+Lightweight data validation utilities powered by DuckDB and sqlglot.
+
+## Concurrency Model
+
+Metric registration and execution engines are safe to use from multiple threads.
+`MetricRegistry` is implemented as a process local singleton protected by an
+`RLock` so concurrent registrations will not corrupt the registry. DuckDB
+connections are pooled inside `DuckDBEngine` which hands out a dedicated
+connection per statement. Each process maintains its own registry and pool so it
+is safe to run tests under `pytest -n auto` or spawn threads in your application.
+

--- a/src/expectations/engines/duckdb.py
+++ b/src/expectations/engines/duckdb.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import contextlib
 from pathlib import Path
+from queue import Queue
 from typing import List, Sequence
 
 import duckdb
@@ -39,9 +40,21 @@ class DuckDBEngine(BaseEngine):
         Open the database in read-only mode (ignored for in-memory DBs).
     """
 
-    def __init__(self, database: str | Path = ":memory:", *, read_only: bool = False):
-        self._conn = duckdb.connect(str(database), read_only=read_only)
+    def __init__(
+        self,
+        database: str | Path = ":memory:",
+        *,
+        read_only: bool = False,
+        pool_size: int = 1,
+    ):
         self._dialect = "duckdb"
+        self._conns: List[duckdb.DuckDBPyConnection] = [
+            duckdb.connect(str(database), read_only=read_only)
+            for _ in range(pool_size)
+        ]
+        self._pool: "Queue[duckdb.DuckDBPyConnection]" = Queue()
+        for conn in self._conns:
+            self._pool.put(conn)
 
     # ------------------------------------------------------------------ #
     # BaseEngine interface                                               #
@@ -57,10 +70,13 @@ class DuckDBEngine(BaseEngine):
         """
         if isinstance(sql, exp.Expression):
             sql = sql.sql(dialect=self._dialect, pretty=False)
+        conn = self._pool.get()
         try:
-            return self._conn.execute(str(sql)).fetchdf()
+            return conn.execute(str(sql)).fetchdf()
         except Exception as exc:  # pragma: no cover
             raise RuntimeError(f"DuckDB query failed: {sql}\n{exc}") from exc
+        finally:
+            self._pool.put(conn)
 
     def run_many(self, sql_statements: Sequence[str | exp.Expression]):  # noqa: D401
         """
@@ -89,29 +105,38 @@ class DuckDBEngine(BaseEngine):
         if "." in table:
             schema, t = table.rsplit(".", 1)
 
-        pragma = f"PRAGMA table_info('{schema}.{t}')" if schema else f"PRAGMA table_info('{t}')"
-        df = self._conn.execute(pragma).fetchdf()
-        return df["name"].tolist()
+        pragma = (
+            f"PRAGMA table_info('{schema}.{t}')" if schema else f"PRAGMA table_info('{t}')"
+        )
+        conn = self._pool.get()
+        try:
+            df = conn.execute(pragma).fetchdf()
+            return df["name"].tolist()
+        finally:
+            self._pool.put(conn)
 
     def get_dialect(self) -> str:  # noqa: D401
         return self._dialect
 
     def close(self):  # noqa: D401
-        with contextlib.suppress(Exception):
-            self._conn.close()
+        for conn in self._conns:
+            with contextlib.suppress(Exception):
+                conn.close()
 
     # ------------------------------------------------------------------ #
     # Convenience helpers                                                #
     # ------------------------------------------------------------------ #
     @property
     def connection(self) -> duckdb.DuckDBPyConnection:  # pragma: no cover
-        """Expose the raw DuckDB connection (useful in notebooks)."""
-        return self._conn
+        """Expose one DuckDB connection (first in the pool)."""
+        return self._conns[0]
 
     def register_dataframe(self, name: str, df: pd.DataFrame) -> None:
         """Register *df* as a DuckDB view for ad-hoc testing."""
-        self._conn.register(name, df)
+        for conn in self._conns:
+            conn.register(name, df)
 
     def __repr__(self) -> str:  # pragma: no cover
-        loc = ":memory:" if self._conn.database_name == ":memory:" else Path(self._conn.database_name).name
+        sample = self._conns[0]
+        loc = ":memory:" if sample.database_name == ":memory:" else Path(sample.database_name).name
         return f"<DuckDBEngine db={loc!r}>"

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from concurrent.futures import ThreadPoolExecutor
+
+from src.expectations.metrics import registry
+from src.expectations.engines.duckdb import DuckDBEngine
+from src.expectations.runner import ValidationRunner
+from src.expectations.validators.column import ColumnNotNull
+
+
+def _worker(i: int) -> bool:
+    name = f"dyn_metric_{i}"
+
+    @registry.register_metric(name)
+    def _metric(col: str):
+        # simple identity metric
+        from sqlglot import exp
+        return exp.column(col)
+
+    eng = DuckDBEngine(pool_size=2)
+    eng.register_dataframe("t", pd.DataFrame({"a": [1, 2]}))
+    runner = ValidationRunner({"duck": eng})
+    res = runner.run([("duck", "t", ColumnNotNull(column="a"))])[0]
+
+    # cleanup
+    registry.MetricRegistry.instance()._metrics.pop(name, None)
+    return res.success
+
+
+def test_parallel_registry_and_engine():
+    with ThreadPoolExecutor(max_workers=4) as exe:
+        results = list(exe.map(_worker, range(4)))
+    assert all(results)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -14,7 +14,7 @@ def test_register_metric_duplicate_key():
         def _metric2(col: str) -> exp.Expression:  # pragma: no cover - should not be executed
             return exp.column(col)
     # cleanup
-    del registry._METRICS["_dup"]
+    registry.MetricRegistry.instance()._metrics.pop("_dup", None)
 
 
 def test_builtin_metric_retrieval():


### PR DESCRIPTION
## Summary
- implement thread-safe `MetricRegistry`
- add connection pooling to `DuckDBEngine`
- document concurrency model
- add concurrency test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b85f9644832a865350a7990ecce3