### PR TITLE
Support custom connection pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Metric registration and execution engines are safe to use from multiple threads.
 `MetricRegistry` is implemented as a process local singleton protected by an
 `RLock` so concurrent registrations will not corrupt the registry. DuckDB
 connections are pooled inside `DuckDBEngine` which hands out a dedicated
-connection per statement. Each process maintains its own registry and pool so it
-is safe to run tests under `pytest -n auto` or spawn threads in your application.
+connection per statement. The pool size defaults to one connection but can be
+increased via the ``pool_size`` argument to accommodate concurrent queries.
+Each process maintains its own registry and pool so it is safe to run tests
+under `pytest -n auto` or spawn threads in your application.
 

--- a/src/expectations/engines/duckdb.py
+++ b/src/expectations/engines/duckdb.py
@@ -38,6 +38,8 @@ class DuckDBEngine(BaseEngine):
         for an ephemeral one.
     read_only : bool, default False
         Open the database in read-only mode (ignored for in-memory DBs).
+    pool_size : int, default 1
+        Number of connections to keep in the internal pool.
     """
 
     def __init__(
@@ -47,6 +49,8 @@ class DuckDBEngine(BaseEngine):
         read_only: bool = False,
         pool_size: int = 1,
     ):
+        if pool_size < 1:
+            raise ValueError("pool_size must be >= 1")
         self._dialect = "duckdb"
         self._conns: List[duckdb.DuckDBPyConnection] = [
             duckdb.connect(str(database), read_only=read_only)

--- a/src/expectations/engines/file.py
+++ b/src/expectations/engines/file.py
@@ -14,12 +14,24 @@ from .duckdb import DuckDBEngine
 
 
 class FileEngine(BaseEngine):
-    """Expose one or more data files as a SQL table via DuckDB."""
+    """Expose one or more data files as a SQL table via DuckDB.
 
-    def __init__(self, path: str | Path, *, table: str = "t", database: str | Path = ":memory:"):
+    Parameters
+    ----------
+    path : str | Path
+        File path or glob pointing to the data files.
+    table : str, default "t"
+        Name of the view exposing the files.
+    database : str | Path, optional
+        DuckDB database for the underlying engine.
+    pool_size : int, default 1
+        Passed through to :class:`DuckDBEngine`.
+    """
+
+    def __init__(self, path: str | Path, *, table: str = "t", database: str | Path = ":memory:", pool_size: int = 1):
         self.path = str(path)
         self.table = table
-        self._duck = DuckDBEngine(database)
+        self._duck = DuckDBEngine(database, pool_size=pool_size)
         # Register view pointing to the file path or glob
         quoted_path = self.path.replace("'", "''")
         self._duck.run_sql(f"CREATE VIEW {self.table} AS SELECT * FROM '{quoted_path}'")


### PR DESCRIPTION
## Summary
- validate pool_size in DuckDBEngine and document it
- add pool_size forwarding to FileEngine
- document pool_size tuning in the concurrency section of README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f017347c832a88602f208e5f7379