### PR TITLE
Fix concurrency pool size

### DIFF
--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -16,7 +16,7 @@ def _worker(i: int) -> bool:
         from sqlglot import exp
         return exp.column(col)
 
-    eng = DuckDBEngine(pool_size=2)
+    eng = DuckDBEngine(pool_size=4)
     eng.register_dataframe("t", pd.DataFrame({"a": [1, 2]}))
     runner = ValidationRunner({"duck": eng})
     res = runner.run([("duck", "t", ColumnNotNull(column="a"))], run_id=f"test_{i}")[0]


### PR DESCRIPTION
## Summary
- adjust DuckDBEngine pool in `test_concurrency` to match thread count

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f10f48d8832abe48c97281a8b839