### PR TITLE
Support YAML round-trip for config objects

### DIFF
--- a/src/expectations/config/expectation.py
+++ b/src/expectations/config/expectation.py
@@ -108,6 +108,12 @@ class ExpectationSuiteConfig(BaseModel):
             return cls.from_json(path)
         raise ValueError(f"Unsupported config extension: {ext}")
 
+    # round-trip helper ----------------------------
+    def to_yaml(self) -> str:
+        """Serialize this config back to YAML."""
+        data = self.model_dump(exclude_defaults=True, exclude_none=True)
+        return yaml.safe_dump(data, sort_keys=False)
+
 
 class SLAConfig(BaseModel):
     """Group multiple expectation suites under a single SLA."""
@@ -146,6 +152,12 @@ class SLAConfig(BaseModel):
         if ext == ".json":
             return cls.from_json(path)
         raise ValueError(f"Unsupported config extension: {ext}")
+
+    # round-trip helper ----------------------------
+    def to_yaml(self) -> str:
+        """Serialize this SLA config back to YAML."""
+        data = self.model_dump(exclude_defaults=True, exclude_none=True)
+        return yaml.safe_dump(data, sort_keys=False)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_expectation_suite.py
+++ b/tests/test_expectation_suite.py
@@ -1,5 +1,6 @@
 import json
 import tempfile
+import yaml
 import pytest
 
 from src.expectations.config.expectation import ExpectationSuiteConfig
@@ -55,6 +56,22 @@ expectations:
     assert len(validators) == 1
     _, _, v = validators[0]
     assert isinstance(v, ColumnNotNull)
+
+
+def test_to_yaml_round_trip(tmp_path):
+    yaml_content = """
+suite_name: s
+engine: duck
+table: t
+expectations:
+  - expectation_type: ColumnNotNull
+    column: a
+"""
+    path = tmp_path / "suite.yml"
+    path.write_text(yaml_content)
+    cfg = ExpectationSuiteConfig.from_yaml(path)
+    dumped = cfg.to_yaml()
+    assert yaml.safe_load(yaml_content) == yaml.safe_load(dumped)
 
 
 def test_from_file_yaml_and_json(tmp_path):

--- a/tests/test_sla_config.py
+++ b/tests/test_sla_config.py
@@ -1,4 +1,5 @@
 import sys
+import yaml
 import src.expectations.validators.column as column_mod
 
 from src.expectations.config.expectation import SLAConfig
@@ -39,3 +40,12 @@ def test_sla_build_validators(tmp_path):
     validators = list(cfg.build_validators())
     assert len(validators) == 2
     assert isinstance(validators[0][2], ColumnNotNull)
+
+
+def test_to_yaml_round_trip(tmp_path):
+    original = _sample_yaml()
+    path = tmp_path / "sla.yml"
+    path.write_text(original)
+    cfg = SLAConfig.from_yaml(path)
+    dumped = cfg.to_yaml()
+    assert yaml.safe_load(original) == yaml.safe_load(dumped)


### PR DESCRIPTION
## Summary
- enable dumping ExpectationSuiteConfig and SLAConfig back to YAML
- test round trip for suite and SLA configs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f2034898832aae147c20902d3c91