### PR TITLE
Fix validator class lookup

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -22,6 +22,20 @@ You can supply your own SQL and have the runner fail when that query returns row
 
 The validator will attach `error_row_count` and a sample of rows to the validation result.
 
+## Hooking Up New Validators
+
+New validator classes live in the `src/expectations/validators` package.
+If you create a new module (for example `foreign_key.py`) you can reference
+its classes from expectation configs either by dotted path
+
+```yaml
+expectation_type: foreign_key.ForeignKeyValidator
+```
+
+or by adding the module name to `src/expectations/validators/__init__.py` so
+that it is loaded automatically.  In that case the class can be referred to
+just by its name.
+
 ## Validating Files Directly
 
 The `FileEngine` exposes one or more files as a regular SQL table backed by DuckDB.

--- a/src/expectations/config/expectation.py
+++ b/src/expectations/config/expectation.py
@@ -164,26 +164,27 @@ class SLAConfig(BaseModel):
 # Internal helpers                                                            #
 # --------------------------------------------------------------------------- #
 def _resolve_validator_class(name: str) -> type[ValidatorBase]:
-    """
-    Resolve *name* (e.g. "ColumnNotNull") to an actual class.
+    """Resolve *name* (e.g. ``ColumnNotNull``) to an actual class."""
 
-    Strategy:
-      1. Look in `src.expectations.validators` sub-modules already imported.
-      2. Fallback to dynamic import.
-    """
-    # optimistic: already in sys.modules
+    pkg_root = "src.expectations.validators"
+
+    # 1) try modules already imported
     for mod_name in list(sys.modules):
-        if mod_name.startswith("src.expectations.validators."):
+        if mod_name.startswith(f"{pkg_root}."):
             mod = sys.modules[mod_name]
             if hasattr(mod, name):
                 return getattr(mod, name)
 
-    # fallback – import checker modules lazily
+    # 2) attempt well-known sub-packages
+    for sub in ("column", "table", "custom"):
+        mod = import_module(f"{pkg_root}.{sub}")
+        if hasattr(mod, name):
+            return getattr(mod, name)
+
+    # 3) final fallback – dotted path supplied
     parts = name.split(".")
     if len(parts) == 1:
-        # assume it's in the default column module
-        mod = import_module("src.expectations.validators.column")
-        return getattr(mod, name)
+        raise AttributeError(f"Validator class {name} not found")
     *pkg, cls_name = parts
     mod = import_module(".".join(pkg))
     return getattr(mod, cls_name)

--- a/src/expectations/validators/__init__.py
+++ b/src/expectations/validators/__init__.py
@@ -1,0 +1,7 @@
+
+"""Convenience imports for common validator modules."""
+
+# Pre-load the core validator sub-modules so that `_resolve_validator_class`
+# can quickly locate classes without the calling code needing to specify
+# dotted paths.
+from . import column, table, custom  # noqa: F401


### PR DESCRIPTION
## Summary
- extend `_resolve_validator_class` to scan `column`, `table` and `custom` modules
- eagerly import those modules when `expectations.validators` package is loaded
- document how to hook up custom validators in the cookbook

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885f772d0c4832aabbf9f32cc89dbcb