### PR TITLE
Switch runtime_id generation to ULID

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest
 pytest-xdist
 faker
 hypothesis
+ulid-py

--- a/src/expectations/validators/base.py
+++ b/src/expectations/validators/base.py
@@ -12,7 +12,8 @@ The runner handles both transparently.
 
 from __future__ import annotations
 
-import uuid
+import os
+import ulid
 from abc import ABC, abstractmethod
 from typing import Literal, Optional
 
@@ -30,7 +31,8 @@ class ValidatorBase(ABC):
     # ------------------------------------------------------------------ #
     def __init__(self, *, where: str | None = None):
         self.where_condition: Optional[str] = where
-        self.runtime_id: str = f"v_{uuid.uuid4().hex[:8]}"
+        # ULID string is 26 chars -> "v<pid>_<ulid>" still well under 63 chars
+        self.runtime_id: str = f"v{os.getpid()}_{ulid.new().str}"
 
     # ------------------------------------------------------------------ #
     # Classification                                                     #

--- a/tests/test_runtime_id.py
+++ b/tests/test_runtime_id.py
@@ -1,0 +1,18 @@
+from src.expectations.validators.base import ValidatorBase
+
+class _Dummy(ValidatorBase):
+    @classmethod
+    def kind(cls):
+        return "custom"
+
+    def custom_sql(self, table: str):
+        return "SELECT 1"
+
+    def interpret(self, value):
+        return True
+
+
+def test_runtime_id_unique_large_sample():
+    ids = {_Dummy().runtime_id for _ in range(1_000_000)}
+    assert len(ids) == 1_000_000
+    assert all(len(i) < 63 for i in ids)


### PR DESCRIPTION
## Summary
- depend on `ulid-py`
- generate runtime IDs from ULIDs prefixed with the PID
- add regression test checking uniqueness of new IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f7ad1aa0832a98f69523eb33632e