### PR TITLE
Add runtime id collision test

### DIFF
--- a/src/expectations/validators/base.py
+++ b/src/expectations/validators/base.py
@@ -30,7 +30,12 @@ class ValidatorBase(ABC):
     # ------------------------------------------------------------------ #
     def __init__(self, *, where: str | None = None):
         self.where_condition: Optional[str] = where
-        self.runtime_id: str = f"v_{uuid.uuid4().hex[:8]}"
+        # Use the full 128-bit UUID to minimize collision probability.
+        #
+        # The chance of a clash among one million instances is
+        # approximately 1.5e-27 when using all 32 hex digits, far below
+        # the 1e-18 threshold.
+        self.runtime_id: str = f"v_{uuid.uuid4().hex}"
 
     # ------------------------------------------------------------------ #
     # Classification                                                     #

--- a/tests/test_runtime_ids.py
+++ b/tests/test_runtime_ids.py
@@ -1,0 +1,13 @@
+import math
+from src.expectations.validators.column import ColumnMin
+
+
+def test_runtime_id_uniqueness():
+    """Ensure generated runtime IDs are unique.
+
+    A runtime ID uses a 128-bit UUID. The probability of *any* collision in
+    ``N`` draws is roughly ``1 - exp(-N*(N-1)/(2*2**128))``. With ``N=10**6``
+    this evaluates to about 1.5e-27, well below 1e-18.
+    """
+    ids = [ColumnMin(column="a", min_value=0).runtime_id for _ in range(1_000_000)]
+    assert len(set(ids)) == len(ids)


### PR DESCRIPTION
## Summary
- use full 128‑bit UUIDs for validator runtime IDs
- add a test generating one million validators and ensure no duplicates exist

## Testing
- `pytest -q tests/test_runtime_ids.py::test_runtime_id_uniqueness`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f976c424832aa82da96f119a2e9f