### PR TITLE
Fix run_many docstring

### DIFF
--- a/src/expectations/engines/duckdb.py
+++ b/src/expectations/engines/duckdb.py
@@ -84,9 +84,11 @@ class DuckDBEngine(BaseEngine):
 
     def run_many(self, sql_statements: Sequence[str | exp.Expression]):  # noqa: D401
         """
-        Execute *multiple* statements in one round-trip by chaining them
-        with semicolons.  Falls back to parent default if an individual
-        statement returns a result set (rare for our use-case).
+        Execute *sql_statements* sequentially and collect the results.
+
+        DuckDB only returns a single result set when multiple statements are
+        chained together, so we simply loop over the statements and call
+        :py:meth:`run_sql` for each one.
         """
         if not sql_statements:
             return []


### PR DESCRIPTION
## Summary
- correct docstring for `DuckDBEngine.run_many`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f9d1a55c832ab0bf0993a0aab96d