### PR TITLE
Implement metric drift and outlier validators

### DIFF
--- a/src/expectations/runner.py
+++ b/src/expectations/runner.py
@@ -43,6 +43,8 @@ class ValidationRunner:
 
         # Split upfront
         for eng_key, table, v in bindings:
+            # expose table on the validator for contextual logic
+            setattr(v, "table", table)
             if v.kind() == "metric":
                 metric_groups[(eng_key, table)].append(v)
             else:

--- a/src/utils/store_context.py
+++ b/src/utils/store_context.py
@@ -1,0 +1,22 @@
+"""Expose a read-only connection from a :class:`DuckDBResultStore`.
+
+The initial implementation simply surfaces the underlying DuckDB connection.
+One alternative would be to wrap the store in the same ``BaseEngine``
+interface used by the validation runner. While that would unify the APIs it
+also introduces another abstraction layer without much benefit because the
+historical validators only need to issue lightweight ``SELECT`` queries.  This
+helper keeps things straightforward and leaves room to add a proper engine
+later should the store grow more complex.
+"""
+
+from contextlib import contextmanager
+from src.expectations.store.duckdb import DuckDBResultStore
+
+
+@contextmanager
+def store_connection(store: DuckDBResultStore):
+    """Yield the underlying connection for ad-hoc read-only queries."""
+    try:
+        yield store.connection
+    finally:
+        pass

--- a/tests/test_anomaly_validators.py
+++ b/tests/test_anomaly_validators.py
@@ -1,0 +1,39 @@
+import pandas as pd
+
+from src.expectations.engines.duckdb import DuckDBEngine
+from src.expectations.store import DuckDBResultStore
+from src.expectations.runner import ValidationRunner
+from src.expectations.validators.column import MetricDriftValidator
+from src.expectations.validators.custom import ColumnZScoreOutlierRowsValidator
+
+
+def _run(eng, table, validator, store=None):
+    runner = ValidationRunner({"duck": eng})
+    return runner.run([("duck", table, validator)], run_id="test")[0]
+
+
+def test_metric_drift_validator(tmp_path):
+    eng = DuckDBEngine()
+    store = DuckDBResultStore(eng)
+    store.connection.execute("DELETE FROM statistics")
+    # insert synthetic history
+    for i, val in enumerate([11, 9, 10, 11, 9, 10, 10, 10, 11, 9]):
+        store.connection.execute(
+            "INSERT INTO statistics VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (f"r{i}", "t", None, None, None, "row_cnt", val),
+        )
+    eng.register_dataframe("t", pd.DataFrame({"a": range(15)}))
+    v = MetricDriftValidator(metric="row_cnt", column=None, result_store=store, window=10, z_thresh=3.0)
+    res = _run(eng, "t", v)
+    assert res.success is False
+    assert v.details["z"] > 3
+
+
+def test_column_zscore_outlier_rows_validator():
+    eng = DuckDBEngine()
+    df = pd.DataFrame({"a": [1, 2, 3, 100]})
+    eng.register_dataframe("t", df)
+    v = ColumnZScoreOutlierRowsValidator(column="a", z_thresh=1.0)
+    res = _run(eng, "t", v)
+    assert res.success is False
+    assert res.details["error_row_count"] == 1


### PR DESCRIPTION
## Summary
- add `MetricDriftValidator` for rolling z‑score checks
- add `ColumnZScoreOutlierRowsValidator` for row level outliers
- expose table name to validators in `ValidationRunner`
- add helper `store_connection`
- test the new validators
- document design rationale for `store_connection`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688600e37818832ab3f2b7437941bc4b