### PR TITLE
Add Streamlit frontend docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,17 @@ that lets you manage expectation suites and trigger runs through HTTP. Results
 are read from the configured ``BaseResultStore`` so any of the included stores
 can be plugged in. The service is intended as a foundation for building a
 custom UI or automation around validation workflows.
+
+## Streamlit Front-end
+
+A lightweight Streamlit app can serve as the user facing layer on top of the
+service. Two common scenarios are:
+
+1. **Explorer / dashboard for validation history** – query the ``/runs`` and
+   ``/runs/{id}`` endpoints or attach directly to the DuckDB result store to
+   render tables and trend charts.
+2. **Interactive suite builder / editor** – use ``st.text_area`` or a form
+   wizard to compose expectation suites and ``POST /suites`` to save them.
+
+Streamlit does not replace the FastAPI service. It only provides a thin UX
+layer, so validations continue to run even if the app is offline.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,3 +5,4 @@ Validator Documentation
    :maxdepth: 2
 
    validators
+   streamlit

--- a/docs/streamlit.rst
+++ b/docs/streamlit.rst
@@ -1,0 +1,55 @@
+Is a Streamlit front-end a good fit? ✅
+====================================
+
+Yes – two complementary use-cases:
+
+Explorer / dashboard for validation history
+------------------------------------------
+Streamlit excels at quick dashboards. You can either query the ``/runs`` and ``/runs/{id}`` endpoints from the service or, if the app runs on the same host, attach directly to the DuckDB result store. Typical widgets include a dropdown for the suite name, multi-select filters for severity and a time-range slider. Results can be rendered with ``st.dataframe`` and trend lines with ``altair`` or ``matplotlib``.
+
+Interactive suite builder / editor
+---------------------------------
+Use a YAML text editor via ``st.text_area`` with syntax highlighting (for example using ``streamlit-ace``) or a form based wizard for non-expert users. The wizard might let the user select a table, pick a validator type and set parameters with a live preview of the YAML. Hitting "Save" should call ``POST /suites`` and provide immediate feedback via a toast notification.
+
+Architectural sketch
+--------------------
+
+.. mermaid::
+
+    graph LR
+        browser((User))
+        subgraph Front-end
+            streamlit(Streamlit app)
+        end
+        subgraph API layer
+            fastapi(FastAPI service\nValidator Service)
+        end
+        db[(DuckDB / JSONL\nResultStore)]
+        fs[(Suite YAML dir)]
+
+        browser --> streamlit
+        streamlit -->|REST: list runs, create suite, trigger run| fastapi
+        fastapi --> db
+        fastapi --> fs
+        streamlit -->|read-only DuckDB (optional)| db
+
+Why keep both?
+--------------
+FastAPI remains the programmatic interface for pipelines or CI, while Streamlit acts purely as a thin user interface layer. If Streamlit goes down, validations still run.
+
+Implementation tips
+-------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Need
+     - Streamlit snippet
+   * - Auto-refresh run table every ``N`` seconds
+     - ``st_autorefresh(interval=30_000)``
+   * - Large tables
+     - ``st.dataframe(df, use_container_width=True)`` with DuckDB's ``to_arrow()`` result
+   * - Code editor
+     - ``from streamlit_ace import st_ace`` – returns YAML string
+   * - Form ↔ Pydantic validation
+     - ``ExpectationSuiteConfig.model_validate_yaml(text)`` to catch errors client-side


### PR DESCRIPTION
## Summary
- document how a Streamlit UI can complement the FastAPI service
- link new `streamlit` doc page from the documentation index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889e2e22ec4832abe5d962079d5b344