### PR TITLE
Add automatic validator schema generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/expectations/engines/__pycache__/
 settings.json
 
 .hypothesis
+src/expectations/validators/validators.json

--- a/src/expectations/validators/__init__.py
+++ b/src/expectations/validators/__init__.py
@@ -5,3 +5,5 @@
 # can quickly locate classes without the calling code needing to specify
 # dotted paths.
 from . import column, table, custom  # noqa: F401
+# Generate validator schema metadata on package import
+from . import schema  # noqa: F401

--- a/src/expectations/validators/schema.py
+++ b/src/expectations/validators/schema.py
@@ -1,0 +1,51 @@
+import importlib
+import inspect
+import json
+import pkgutil
+from pathlib import Path
+from typing import get_type_hints
+
+from .base import ValidatorBase
+
+
+def _discover_validators():
+    pkg_path = Path(__file__).resolve().parent
+    validators = {}
+
+    for info in pkgutil.iter_modules([str(pkg_path)]):
+        if info.name.startswith("_") or info.name == "schema":
+            continue
+        module = importlib.import_module(f"{__package__}.{info.name}")
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            if obj.__module__ != module.__name__:
+                continue
+            if not issubclass(obj, ValidatorBase) or obj in {ValidatorBase}:
+                continue
+            if name == "ColumnMetricValidator":
+                continue
+            doc = inspect.getdoc(obj) or ""
+            sig = inspect.signature(obj.__init__)
+            hints = get_type_hints(obj.__init__)
+            params = []
+            for p in list(sig.parameters.values())[1:]:
+                meta = {"name": p.name}
+                if p.name in hints:
+                    meta["type"] = str(hints[p.name])
+                if p.default is not inspect.Parameter.empty:
+                    meta["default"] = p.default
+                params.append(meta)
+            validators[name] = {"doc": doc, "params": params}
+    return validators
+
+
+def _write_schema(data):
+    pkg_path = Path(__file__).resolve().parent
+    out_file = pkg_path / "validators.json"
+    if out_file.exists():
+        return
+    out_file.write_text(json.dumps(data, indent=2, default=str))
+
+
+schema = _discover_validators()
+_write_schema(schema)
+

--- a/tests/test_validator_schema.py
+++ b/tests/test_validator_schema.py
@@ -1,0 +1,16 @@
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+def test_validator_schema_contains_known_validator():
+    sys.modules.pop('src.expectations.validators.schema', None)
+    sys.modules.pop('src.expectations.validators', None)
+    pkg = importlib.import_module('src.expectations.validators')
+
+    out_file = Path(pkg.__file__).with_name('validators.json')
+    assert out_file.exists(), 'validators.json was not created'
+
+    data = json.loads(out_file.read_text())
+    assert 'ColumnNullPct' in data


### PR DESCRIPTION
## Summary
- discover validator classes on import
- generate validators.json under validators package
- ensure validators package imports schema generator
- ignore generated JSON in repo
- test that validators.json is created and contains ColumnNullPct

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889f2e1d324832a800a3528eeaea4d7