### PR TITLE
Add Streamlit widget helper and form demo

### DIFF
--- a/src/service/api.py
+++ b/src/service/api.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List
+import os
+import sys
 
 from fastapi import FastAPI, HTTPException
 
-from src.expectations.config.expectation import ExpectationSuiteConfig
+try:
+    from src.expectations.config.expectation import ExpectationSuiteConfig
+except ImportError:  # pragma: no cover - dev dependency
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+    from src.expectations.config.expectation import ExpectationSuiteConfig
 from src.expectations.runner import ValidationRunner
 from src.expectations.store.base import BaseResultStore
 from src.expectations.workflow import run_validations

--- a/src/service/streamlit_app.py
+++ b/src/service/streamlit_app.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import os
-from typing import List
+import sys
+from typing import List, Dict, Any
+from pathlib import Path
+import json
 
 import pandas as pd
 import requests
 import streamlit as st
+
+from .widgets import widget_for
 
 try:  # optional dependency used for nicer YAML editing
     from streamlit_ace import st_ace  # type: ignore
@@ -16,7 +21,11 @@ except Exception:  # pragma: no cover - dev dependency
 
 import duckdb
 
-from src.expectations.config.expectation import ExpectationSuiteConfig
+try:
+    from src.expectations.config.expectation import ExpectationSuiteConfig
+except ImportError:  # pragma: no cover - dev dependency
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+    from src.expectations.config.expectation import ExpectationSuiteConfig
 
 
 SERVICE_URL = os.getenv("SERVICE_URL", "http://localhost:8000")
@@ -24,6 +33,14 @@ SERVICE_URL = os.getenv("SERVICE_URL", "http://localhost:8000")
 
 DUCKDB_PATH = os.getenv("RESULT_DB")
 """Optional path to a DuckDB database for read-only history lookup."""
+
+# Load validator field metadata for form generation
+_SCHEMA_PATH = Path(__file__).resolve().parents[2] / "validators.json"
+try:
+    with open(_SCHEMA_PATH, "r") as fh:
+        VALIDATOR_SCHEMA: Dict[str, Dict[str, Any]] = json.load(fh)
+except FileNotFoundError:  # pragma: no cover - demo scenario
+    VALIDATOR_SCHEMA = {}
 
 
 @st.cache_data(show_spinner=False)
@@ -87,6 +104,17 @@ def _trigger_run(suite_name: str) -> None:
     resp.raise_for_status()
 
 
+def build_validator_form(validator: str) -> Dict[str, Any]:
+    """Render input widgets for *validator* based on ``VALIDATOR_SCHEMA``."""
+
+    fields = VALIDATOR_SCHEMA.get(validator, {})
+    values: Dict[str, Any] = {}
+    for name, meta in fields.items():
+        widget_key = f"{validator}-{name}"
+        values[name] = widget_for(name, meta, widget_key)
+    return values
+
+
 def page_runs() -> None:
     st.header("Validation Runs")
     # NOTE: ``st.autorefresh`` was renamed to ``st_autorefresh`` in newer
@@ -120,6 +148,18 @@ def page_runs() -> None:
             st.info("No results found")
         else:
             st.dataframe(res, use_container_width=True)
+
+
+def page_form_demo() -> None:
+    """Demonstrate dynamic form generation for a validator."""
+
+    st.header("Validator Form Demo")
+    validator = st.selectbox("Validator", sorted(VALIDATOR_SCHEMA.keys()))
+    with st.form("validator_form"):
+        values = build_validator_form(validator)
+        submitted = st.form_submit_button("Submit")
+    if submitted:
+        st.json(values)
 
 
 def page_editor() -> None:
@@ -156,11 +196,15 @@ def page_editor() -> None:
 
 def main() -> None:  # pragma: no cover - interactive
     st.title("Validator UI")
-    page = st.sidebar.selectbox("Page", ["Runs", "Suite Builder"])
+    page = st.sidebar.selectbox(
+        "Page", ["Runs", "Suite Builder", "Validator Demo"]
+    )
     if page == "Runs":
         page_runs()
-    else:
+    elif page == "Suite Builder":
         page_editor()
+    else:
+        page_form_demo()
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution

--- a/src/service/widgets.py
+++ b/src/service/widgets.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Reusable Streamlit widgets."""
+
+from typing import Any, Dict
+
+import streamlit as st
+
+
+def widget_for(name: str, meta: Dict[str, Any], key: str):
+    """Return a Streamlit input widget for *name* based on *meta*."""
+
+    field_type = meta.get("type")
+    label = meta.get("label", name)
+    if field_type == "choice":
+        options = meta.get("options", [])
+        return st.selectbox(label, options, key=key)
+    if field_type == "number":
+        return st.number_input(label, key=key)
+    if field_type == "bool":
+        return st.checkbox(label, key=key)
+    return st.text_input(label, key=key)

--- a/tests/test_expectation_suite.py
+++ b/tests/test_expectation_suite.py
@@ -2,10 +2,15 @@ import json
 import tempfile
 import yaml
 import pytest
-
-from src.expectations.config.expectation import ExpectationSuiteConfig
-from src.expectations.validators.column import ColumnNotNull
+import os
 import sys
+
+try:
+    from src.expectations.config.expectation import ExpectationSuiteConfig
+except ImportError:  # pragma: no cover - dev dependency
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+    from src.expectations.config.expectation import ExpectationSuiteConfig
+from src.expectations.validators.column import ColumnNotNull
 import src.expectations.validators.column as column_mod
 
 

--- a/tests/test_integration_suite.py
+++ b/tests/test_integration_suite.py
@@ -1,8 +1,13 @@
 import pandas as pd
+import os
 import sys
 from src.expectations.engines.duckdb import DuckDBEngine
 from src.expectations.runner import ValidationRunner
-from src.expectations.config.expectation import ExpectationSuiteConfig
+try:
+    from src.expectations.config.expectation import ExpectationSuiteConfig
+except ImportError:  # pragma: no cover - dev dependency
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+    from src.expectations.config.expectation import ExpectationSuiteConfig
 from src.expectations.validators.custom import SqlErrorRowsValidator
 from src.expectations.validators.table import RowCountValidator, DuplicateRowValidator
 

--- a/tests/test_result_store.py
+++ b/tests/test_result_store.py
@@ -77,7 +77,13 @@ def test_duckdb_store_persist_sla(tmp_path):
     store.connection.execute("DELETE FROM results")
     store.connection.execute("DELETE FROM slas")
 
-    from src.expectations.config.expectation import SLAConfig, ExpectationSuiteConfig
+    import os
+    import sys
+    try:
+        from src.expectations.config.expectation import SLAConfig, ExpectationSuiteConfig
+    except ImportError:  # pragma: no cover - dev dependency
+        sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+        from src.expectations.config.expectation import SLAConfig, ExpectationSuiteConfig
 
     sla_cfg = SLAConfig(
         sla_name="sla1",

--- a/tests/test_sql_error_rows.py
+++ b/tests/test_sql_error_rows.py
@@ -1,11 +1,16 @@
 import pandas as pd
+import os
 import sys
 
 from src.expectations.engines.duckdb import DuckDBEngine
 from src.expectations.runner import ValidationRunner
 from src.expectations.validators.custom import SqlErrorRowsValidator
 from src.expectations.validators.column import ColumnNotNull
-from src.expectations.config.expectation import ExpectationSuiteConfig
+try:
+    from src.expectations.config.expectation import ExpectationSuiteConfig
+except ImportError:  # pragma: no cover - dev dependency
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+    from src.expectations.config.expectation import ExpectationSuiteConfig
 
 
 def _run(eng, table, validator):

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,0 +1,26 @@
+import streamlit as st
+import pytest
+
+from src.service.widgets import widget_for
+
+
+@pytest.mark.parametrize(
+    "meta, expected",
+    [
+        ({"type": "choice", "options": [1]}, "selectbox"),
+        ({"type": "number"}, "number_input"),
+        ({"type": "bool"}, "checkbox"),
+        ({}, "text_input"),
+    ],
+)
+def test_widget_for(monkeypatch, meta, expected):
+    calls = []
+
+    monkeypatch.setattr(st, "selectbox", lambda *a, **kw: calls.append("selectbox"))
+    monkeypatch.setattr(st, "number_input", lambda *a, **kw: calls.append("number_input"))
+    monkeypatch.setattr(st, "checkbox", lambda *a, **kw: calls.append("checkbox"))
+    monkeypatch.setattr(st, "text_input", lambda *a, **kw: calls.append("text_input"))
+
+    widget_for("field", meta, "key")
+    assert calls == [expected]
+

--- a/validators.json
+++ b/validators.json
@@ -1,0 +1,17 @@
+{
+  "RowCountValidator": {
+    "min_rows": {"type": "number"},
+    "max_rows": {"type": "number"},
+    "where": {"type": "text"}
+  },
+  "SqlErrorRowsValidator": {
+    "sql": {"type": "text"},
+    "max_error_rows": {"type": "number"},
+    "severity": {"type": "choice", "options": ["INFO", "WARN", "FAIL"]}
+  },
+  "ColumnValueInSet": {
+    "column": {"type": "text"},
+    "allowed_values": {"type": "choice", "options": ["OPEN", "CLOSED"]},
+    "allow_null": {"type": "bool"}
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable widget generator `widget_for`
- load validator schemas from `validators.json`
- build dynamic form demo in Streamlit app
- test widget selection logic
- ensure imports of `ExpectationSuiteConfig` work even if package not installed

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889f2e7b584832ab47e920c0b4ac3ac