### PR TITLE
Add reconciliation validators

### DIFF
--- a/src/expectations/validators/__init__.py
+++ b/src/expectations/validators/__init__.py
@@ -4,6 +4,6 @@
 # Pre-load the core validator sub-modules so that `_resolve_validator_class`
 # can quickly locate classes without the calling code needing to specify
 # dotted paths.
-from . import column, table, custom  # noqa: F401
+from . import column, table, custom, reconciliation  # noqa: F401
 # Generate validator schema metadata on package import
 from . import schema  # noqa: F401

--- a/src/expectations/validators/reconciliation.py
+++ b/src/expectations/validators/reconciliation.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+"""Validators for reconciling tables and columns across engines."""
+
+from typing import Sequence
+
+import pandas as pd
+
+from src.expectations.engines.base import BaseEngine
+from src.expectations.metrics.batch_builder import MetricBatchBuilder, MetricRequest
+from src.expectations.validators.base import ValidatorBase
+from src.expectations.validators.column import ColumnMetricValidator
+
+
+class ColumnReconciliationValidator(ColumnMetricValidator):
+    """Compare simple column metrics between two engines.
+
+    The validator runs a set of basic metrics on the *primary* engine and the
+    provided ``comparer_engine`` and succeeds when all metrics match exactly.
+
+    Parameters
+    ----------
+    column : str
+        Column name on the primary table.
+    comparer_engine : BaseEngine
+        Engine used for the comparison query.
+    comparer_table : str
+        Table name on the comparer engine.
+    comparer_column : str, optional
+        Column on the comparer table; defaults to ``column``.
+    where : str, optional
+        Optional SQL filter for the primary engine.
+    comparer_where : str, optional
+        Optional SQL filter for the comparer engine.
+    """
+
+    _metric_key = "row_cnt"  # unused but required by ``ColumnMetricValidator``
+    _metrics: Sequence[str] = (
+        "row_cnt",
+        "min",
+        "max",
+    )
+
+    def __init__(
+        self,
+        *,
+        column: str,
+        comparer_engine: BaseEngine,
+        comparer_table: str,
+        comparer_column: str | None = None,
+        where: str | None = None,
+        comparer_where: str | None = None,
+    ) -> None:
+        super().__init__(column=column, where=where)
+        self.comparer_engine = comparer_engine
+        self.comparer_table = comparer_table
+        self.comparer_column = comparer_column or column
+        self.comparer_where = comparer_where
+
+    # ---- ValidatorBase interface ------------------------------------
+    @classmethod
+    def kind(cls) -> str:
+        return "custom"
+
+    def custom_sql(self, table: str):
+        requests = []
+        for metric in self._metrics:
+            col = self.column if metric != "row_cnt" else "*"
+            requests.append(
+                MetricRequest(
+                    column=col,
+                    metric=metric,
+                    alias=metric,
+                    filter_sql=self.where_condition,
+                )
+            )
+        return MetricBatchBuilder(table=table, requests=requests).build_query_ast()
+
+    def interpret(self, df: pd.DataFrame) -> bool:
+        row = df.iloc[0]
+        primary = {m: row[m] for m in self._metrics}
+
+        cmp_requests = []
+        for metric in self._metrics:
+            col = self.comparer_column if metric != "row_cnt" else "*"
+            cmp_requests.append(
+                MetricRequest(
+                    column=col,
+                    metric=metric,
+                    alias=metric,
+                    filter_sql=self.comparer_where,
+                )
+            )
+        sql = MetricBatchBuilder(
+            table=self.comparer_table, requests=cmp_requests
+        ).build_query_ast()
+        cmp_df = self.comparer_engine.run_sql(sql)
+        cmp_row = cmp_df.iloc[0]
+        comparer = {m: cmp_row[m] for m in self._metrics}
+
+        self.details = {"primary": primary, "comparer": comparer}
+        return primary == comparer
+
+
+class TableReconciliationValidator(ValidatorBase):
+    """Compare table row counts between two engines."""
+
+    def __init__(
+        self,
+        *,
+        comparer_engine: BaseEngine,
+        comparer_table: str,
+        where: str | None = None,
+        comparer_where: str | None = None,
+    ) -> None:
+        super().__init__(where=where)
+        self.comparer_engine = comparer_engine
+        self.comparer_table = comparer_table
+        self.comparer_where = comparer_where
+
+    @classmethod
+    def kind(cls) -> str:
+        return "custom"
+
+    def custom_sql(self, table: str):
+        request = MetricRequest(
+            column="*",
+            metric="row_cnt",
+            alias="row_cnt",
+            filter_sql=self.where_condition,
+        )
+        return MetricBatchBuilder(table=table, requests=[request]).build_query_ast()
+
+    def interpret(self, df: pd.DataFrame) -> bool:
+        primary_cnt = int(df.iloc[0]["row_cnt"]) if not df.empty else 0
+
+        cmp_request = MetricRequest(
+            column="*",
+            metric="row_cnt",
+            alias="row_cnt",
+            filter_sql=self.comparer_where,
+        )
+        sql = MetricBatchBuilder(
+            table=self.comparer_table, requests=[cmp_request]
+        ).build_query_ast()
+        cmp_df = self.comparer_engine.run_sql(sql)
+        comparer_cnt = int(cmp_df.iloc[0]["row_cnt"]) if not cmp_df.empty else 0
+
+        self.details = {"primary": primary_cnt, "comparer": comparer_cnt}
+        return primary_cnt == comparer_cnt

--- a/tests/test_reconciliation_validators.py
+++ b/tests/test_reconciliation_validators.py
@@ -1,0 +1,60 @@
+import pandas as pd
+
+import pandas as pd
+
+from src.expectations.engines.duckdb import DuckDBEngine
+from src.expectations.runner import ValidationRunner
+from src.expectations.validators.reconciliation import (
+    ColumnReconciliationValidator,
+    TableReconciliationValidator,
+)
+
+
+def _run(eng_map, table, validator):
+    runner = ValidationRunner(eng_map)
+    # primary engine key assumed to be 'primary'
+    return runner.run([("primary", table, validator)], run_id="test")[0]
+
+
+def test_table_reconciliation_validator():
+    primary = DuckDBEngine()
+    comparer = DuckDBEngine()
+    primary.register_dataframe("t1", pd.DataFrame({"a": [1, 2, 3]}))
+    comparer.register_dataframe("t2", pd.DataFrame({"a": [1, 2, 3]}))
+
+    v_pass = TableReconciliationValidator(
+        comparer_engine=comparer, comparer_table="t2"
+    )
+    res_pass = _run({"primary": primary, "comp": comparer}, "t1", v_pass)
+    assert res_pass.success is True
+
+    comparer.register_dataframe("t3", pd.DataFrame({"a": [1]}))
+    v_fail = TableReconciliationValidator(
+        comparer_engine=comparer, comparer_table="t3"
+    )
+    res_fail = _run({"primary": primary, "comp": comparer}, "t1", v_fail)
+    assert res_fail.success is False
+    assert res_fail.details["primary"] == 3
+    assert res_fail.details["comparer"] == 1
+
+
+def test_column_reconciliation_validator():
+    primary = DuckDBEngine()
+    comparer = DuckDBEngine()
+    primary.register_dataframe("t1", pd.DataFrame({"a": [1, 2, 3]}))
+    comparer.register_dataframe("t2", pd.DataFrame({"a": [1, 2, 3]}))
+
+    v_pass = ColumnReconciliationValidator(
+        column="a", comparer_engine=comparer, comparer_table="t2"
+    )
+    res_pass = _run({"primary": primary, "comp": comparer}, "t1", v_pass)
+    assert res_pass.success is True
+
+    comparer.register_dataframe("t3", pd.DataFrame({"a": [1, 5]}))
+    v_fail = ColumnReconciliationValidator(
+        column="a", comparer_engine=comparer, comparer_table="t3"
+    )
+    res_fail = _run({"primary": primary, "comp": comparer}, "t1", v_fail)
+    assert res_fail.success is False
+    assert res_fail.details["primary"]["row_cnt"] == 3
+    assert res_fail.details["comparer"]["row_cnt"] == 2


### PR DESCRIPTION
## Summary
- add column/table reconciliation validators comparing metrics across engines
- expose comparer engine/table/column options with diagnostic details

## Testing
- `pytest tests/test_reconciliation_validators.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688efac25a08832a9a3ebec527b15e07