### PR TITLE
feat: add helper to register predicate metrics

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -36,6 +36,21 @@ or by adding the module name to `src/expectations/validators/__init__.py` so
 that it is loaded automatically.  In that case the class can be referred to
 just by its name.
 
+## Registering Predicate Metrics
+
+Metric builders can be extended with custom percentage metrics based on SQL
+predicates.  The :func:`register_pct_where` helper wraps ``pct_where`` and
+registers the resulting builder under a given name:
+
+```python
+from src.expectations.metrics.registry import register_pct_where
+
+register_pct_where("b_is_one_pct", "b = 1")
+```
+
+The new metric can then be referenced via ``b_is_one_pct`` in expectation
+configurations or when collecting statistics.
+
 ## Validating Files Directly
 
 The `FileEngine` exposes one or more files as a regular SQL table backed by DuckDB.

--- a/src/expectations/metrics/registry.py
+++ b/src/expectations/metrics/registry.py
@@ -185,6 +185,34 @@ def pct_where(predicate_sql: str) -> MetricBuilder:
     return _builder
 
 
+def register_pct_where(name: str, predicate_sql: str) -> MetricBuilder:
+    """Register a ``pct_where`` metric under ``name``.
+
+    Parameters
+    ----------
+    name:
+        Key used when looking up the metric via :func:`get_metric`.
+    predicate_sql:
+        SQL predicate evaluated per row. The resulting metric expresses the
+        percentage of rows for which the predicate is true.
+
+    Returns
+    -------
+    MetricBuilder
+        The registered builder, equivalent to :func:`pct_where(predicate_sql)`.
+
+    Examples
+    --------
+    >>> register_pct_where("b_is_one_pct", "b = 1")
+    >>> builder = get_metric("b_is_one_pct")
+    >>> builder("a")  # expression for percentage of rows where b equals 1
+    """
+
+    builder = pct_where(predicate_sql)
+    MetricRegistry.instance().register(name, builder)
+    return builder
+
+
 # --------------------------------------------------------------------------- #
 # Set comparison metrics                                                      #
 # --------------------------------------------------------------------------- #

--- a/tests/test_metric_builders.py
+++ b/tests/test_metric_builders.py
@@ -63,3 +63,16 @@ def test_pct_where_builder(tmp_path):
     expr = builder("a")
     val = _run_expr(eng, "t", expr)
     assert val == approx(2 / 3)
+
+
+def test_register_pct_where(tmp_path):
+    eng = DuckDBEngine()
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [1, 0, 1]})
+    eng.register_dataframe("t", df)
+
+    from src.expectations.metrics.registry import get_metric, register_pct_where
+
+    register_pct_where("b_is_one_pct", "b = 1")
+    expr = get_metric("b_is_one_pct")("a")
+    val = _run_expr(eng, "t", expr)
+    assert val == approx(2 / 3)


### PR DESCRIPTION
## Summary
- add `register_pct_where` helper to create and register predicate-based metrics
- document predicate metric registration in cookbook
- test metric registration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f05b1d748832abc41cc1d71922a1e