### PR TITLE
feat: expand reconciliation helpers for comparer engines

### DIFF
--- a/src/expectations/runner.py
+++ b/src/expectations/runner.py
@@ -100,7 +100,11 @@ class ValidationRunner:
         for eng_key, table, v in custom_bindings:
             engine = self.engine_map[eng_key]
             sql_or_ast = v.custom_sql(table)
-            sql = sql_or_ast.sql() if isinstance(sql_or_ast, exp.Expression) else str(sql_or_ast)
+            sql = (
+                sql_or_ast.sql(dialect=engine.get_dialect())
+                if isinstance(sql_or_ast, exp.Expression)
+                else str(sql_or_ast)
+            )
             err = ""
             err_tb = ""
             try:

--- a/src/expectations/utils/__init__.py
+++ b/src/expectations/utils/__init__.py
@@ -1,2 +1,7 @@
 """Utility helpers for expectations package."""
 
+from .engines import create_engine, create_comparer_engine
+from .comparer import run_metrics
+
+__all__ = ["create_engine", "create_comparer_engine", "run_metrics"]
+

--- a/src/expectations/utils/comparer.py
+++ b/src/expectations/utils/comparer.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Helpers for running metrics on a secondary comparer engine."""
+
+from typing import Any, Dict, Sequence
+
+import pandas as pd
+
+from src.expectations.engines.base import BaseEngine
+from src.expectations.metrics.batch_builder import MetricBatchBuilder, MetricRequest
+
+
+def run_metrics(
+    engine: BaseEngine,
+    table: str,
+    requests: Sequence[MetricRequest],
+) -> Dict[str, Any]:
+    """Execute *requests* on *engine* and return a mapping of alias to value."""
+    if not requests:
+        return {}
+
+    sql = MetricBatchBuilder(table=table, requests=requests).build_query_ast()
+    df: pd.DataFrame = engine.run_sql(sql)
+    if df.empty:
+        return {r.alias: None for r in requests}
+    row = df.iloc[0]
+    return {r.alias: row[r.alias] for r in requests}

--- a/src/expectations/utils/engines.py
+++ b/src/expectations/utils/engines.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Utility helpers for building execution engines."""
+
+from typing import Any, Dict, Type
+
+from src.expectations.engines.base import BaseEngine
+from src.expectations.engines import DuckDBEngine, FileEngine
+
+_ENGINE_REGISTRY: Dict[str, Type[BaseEngine]] = {
+    "duckdb": DuckDBEngine,
+    "file": FileEngine,
+}
+
+
+def create_engine(kind: str, **kwargs: Any) -> BaseEngine:
+    """Instantiate an engine by *kind* using registered implementations."""
+    try:
+        cls = _ENGINE_REGISTRY[kind]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unknown engine type: {kind}") from exc
+    return cls(**kwargs)
+
+
+def create_comparer_engine(kind: str, **kwargs: Any) -> BaseEngine:
+    """Thin wrapper around :func:`create_engine` for clarity."""
+    return create_engine(kind, **kwargs)

--- a/src/expectations/utils/mappings.py
+++ b/src/expectations/utils/mappings.py
@@ -31,12 +31,18 @@ class ColumnMapping:
         Callable used to convert metric results from the primary column.
     comparer_type: callable, optional
         Callable used to convert metric results from the comparer column.
+    primary_case: str, optional
+        Normalize string case for primary values ("lower" or "upper").
+    comparer_case: str, optional
+        Normalize string case for comparer values ("lower" or "upper").
     """
 
     primary: str
     comparer: str | None = None
     primary_type: Callable[[Any], Any] | None = None
     comparer_type: Callable[[Any], Any] | None = None
+    primary_case: str | None = None
+    comparer_case: str | None = None
 
     def convert(self, primary_value: Any, comparer_value: Any) -> tuple[Any, Any]:
         """Apply type conversions to metric results."""
@@ -45,6 +51,19 @@ class ColumnMapping:
             primary_value = self.primary_type(primary_value)
         if self.comparer_type is not None:
             comparer_value = self.comparer_type(comparer_value)
+
+        if self.primary_case and isinstance(primary_value, str):
+            if self.primary_case.lower() == "lower":
+                primary_value = primary_value.lower()
+            elif self.primary_case.lower() == "upper":
+                primary_value = primary_value.upper()
+
+        if self.comparer_case and isinstance(comparer_value, str):
+            if self.comparer_case.lower() == "lower":
+                comparer_value = comparer_value.lower()
+            elif self.comparer_case.lower() == "upper":
+                comparer_value = comparer_value.upper()
+
         return primary_value, comparer_value
 
 

--- a/tests/test_reconciliation_validators.py
+++ b/tests/test_reconciliation_validators.py
@@ -89,6 +89,24 @@ def test_column_mapping_with_renames_and_conversion():
     assert res.success is True
 
 
+def test_column_mapping_with_case_normalization():
+    primary = DuckDBEngine()
+    comparer = DuckDBEngine()
+    primary.register_dataframe("t1", pd.DataFrame({"a": ["A", "B"]}))
+    comparer.register_dataframe("t2", pd.DataFrame({"a": ["a", "b"]}))
+
+    mapping = ColumnMapping("a", primary_case="lower", comparer_case="lower")
+    v = ColumnReconciliationValidator(
+        column_map=mapping,
+        primary_engine=primary,
+        primary_table="t1",
+        comparer_engine=comparer,
+        comparer_table="t2",
+    )
+    res = _run({"primary": primary, "comp": comparer}, "t1", v)
+    assert res.success is True
+
+
 
 def test_column_reconciliation_mismatched_schema():
     primary = DuckDBEngine()


### PR DESCRIPTION
## Summary
- add engine factory utilities and comparer metric helper
- allow ColumnMapping to cast and normalize case
- run metrics on secondary engines in reconciliation validators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f0f242b04832a9c0b61937e701322