### PR TITLE
docs: expand reconciliation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,23 @@ Example configuration::
       - expectation_type: TableReconciliationValidator
         comparer_engine: warehouse
         comparer_table: users_copy
+        where: "active = 1"
+        comparer_where: "status = 'active'"
       - expectation_type: ColumnReconciliationValidator
         column_map:
           primary: id
+          comparer: user_id
+          comparer_type: int
         primary_engine: duck
         primary_table: users
         comparer_engine: warehouse
         comparer_table: users_copy
+        where: "active = 1"
+        comparer_where: "status = 'active'"
 
 Best practices:
 
 * Run the table validator first to detect large discrepancies early.
 * Apply matching ``where`` clauses on both engines when filtering data.
 * Use :class:`ColumnMapping` to handle renamed columns or type conversions.
+* Keep mappings small and focused; reconcile one column at a time for clear errors.

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -158,13 +158,19 @@ Example YAML::
     - expectation_type: TableReconciliationValidator
       comparer_engine: file
       comparer_table: staging_users
+      where: "active = 1"
+      comparer_where: "status = 'active'"
     - expectation_type: ColumnReconciliationValidator
       column_map:
         primary: id
+        comparer: user_id
+        comparer_type: int
       primary_engine: duck
       primary_table: users
       comparer_engine: file
       comparer_table: staging_users
+      where: "active = 1"
+      comparer_where: "status = 'active'"
 
 Tips
 ----
@@ -172,3 +178,4 @@ Tips
 * Apply identical ``where`` filters on both engines if validating a subset.
 * Column mappings support renames and type conversions for heterogeneous
   sources.
+* Reconcile one column at a time to keep results interpretable.

--- a/src/expectations/metrics/registry.py
+++ b/src/expectations/metrics/registry.py
@@ -103,8 +103,12 @@ def available_metrics() -> Tuple[str, ...]:
 # ------------------------------------------------------------------ #
 @register_metric("null_pct")
 def _null_pct(column: str) -> exp.Expression:
-    """
-    SUM(CASE WHEN col IS NULL THEN 1 ELSE 0 END) / COUNT(*)
+    """Percentage of ``NULL`` values in *column*.
+
+    Examples
+    --------
+    >>> _null_pct("a").sql()
+    "SUM(CASE WHEN a IS NULL THEN 1 ELSE 0 END) / COUNT(*)"
     """
     col_expr = exp.column(column)
     case_expr = (
@@ -121,32 +125,62 @@ def _null_pct(column: str) -> exp.Expression:
 
 @register_metric("distinct_cnt")
 def _distinct_cnt(column: str) -> exp.Expression:
-    """COUNT(DISTINCT col)"""
+    """Count of distinct values in *column*.
+
+    Examples
+    --------
+    >>> _distinct_cnt("a").sql()
+    'COUNT(DISTINCT a)'
+    """
     distinct = exp.Distinct(expressions=[exp.column(column)])
     return exp.Count(this=distinct)
 
 
 @register_metric("row_cnt")
 def _row_cnt(_: str) -> exp.Expression:
-    """COUNT(*)"""
+    """Total row count for the current table.
+
+    Examples
+    --------
+    >>> _row_cnt("irrelevant").sql()
+    'COUNT(*)'
+    """
     return exp.Count(this=exp.Star())
 
 
 @register_metric("min")
 def _min(column: str) -> exp.Expression:
-    """MIN(col)"""
+    """Minimum value of *column*.
+
+    Examples
+    --------
+    >>> _min("a").sql()
+    'MIN(a)'
+    """
     return exp.Min(this=exp.column(column))
 
 
 @register_metric("max")
 def _max(column: str) -> exp.Expression:
-    """MAX(col)"""
+    """Maximum value of *column*.
+
+    Examples
+    --------
+    >>> _max("a").sql()
+    'MAX(a)'
+    """
     return exp.Max(this=exp.column(column))
 
 
 @register_metric("non_null_cnt")
 def _non_null_cnt(column: str) -> exp.Expression:
-    """COUNT(CASE WHEN col IS NOT NULL THEN 1 END)"""
+    """Count of non-``NULL`` values in *column*.
+
+    Examples
+    --------
+    >>> _non_null_cnt("a").sql()
+    'COUNT(CASE WHEN a IS NOT NULL THEN 1 END)'
+    """
     col_expr = exp.column(column)
     case_expr = (
         exp.Case()
@@ -158,13 +192,25 @@ def _non_null_cnt(column: str) -> exp.Expression:
 
 @register_metric("avg")
 def _avg(column: str) -> exp.Expression:
-    """AVG(col)"""
+    """Average (mean) of *column*.
+
+    Examples
+    --------
+    >>> _avg("a").sql()
+    'AVG(a)'
+    """
     return exp.Avg(this=exp.column(column))
 
 
 @register_metric("stddev")
 def _stddev(column: str) -> exp.Expression:
-    """STDDEV_SAMP(col)"""
+    """Sample standard deviation of *column*.
+
+    Examples
+    --------
+    >>> _stddev("a").sql()
+    'STDDEV_SAMP(a)'
+    """
     return exp.StddevSamp(this=exp.column(column))
 
 

--- a/src/expectations/validators/reconciliation.py
+++ b/src/expectations/validators/reconciliation.py
@@ -40,17 +40,34 @@ class ColumnReconciliationValidator(ColumnMetricValidator):
 
     Examples
     --------
-    Basic usage compares the same column on two engines:
+    Basic usage compares the same column on two engines::
 
-    >>> mapping = ColumnMapping("a")
-    >>> ColumnReconciliationValidator(
-    ...     column_map=mapping,
-    ...     primary_engine=primary,
-    ...     primary_table="t1",
-    ...     comparer_engine=comparer,
-    ...     comparer_table="t2",
-    ... )
-    <ColumnReconciliationValidator>
+        mapping = ColumnMapping("a")
+        ColumnReconciliationValidator(
+            column_map=mapping,
+            primary_engine=primary,
+            primary_table="t1",
+            comparer_engine=comparer,
+            comparer_table="t2",
+        )
+
+    Column mappings can rename and cast values::
+
+        mapping = ColumnMapping(
+            primary="id",
+            comparer="user_id",
+            comparer_type=int,
+        )
+        ColumnReconciliationValidator(
+            column_map=mapping,
+            primary_engine=primary,
+            primary_table="users",
+            comparer_engine=comparer,
+            comparer_table="users_copy",
+            where="active = 1",
+            comparer_where="status = 'active'",
+        )
+        <ColumnReconciliationValidator>
     """
 
     _metric_key = "row_cnt"  # unused but required by ``ColumnMetricValidator``
@@ -136,13 +153,35 @@ class ColumnReconciliationValidator(ColumnMetricValidator):
 class TableReconciliationValidator(ValidatorBase):
     """Compare table row counts between two engines.
 
+    Parameters
+    ----------
+    comparer_engine : BaseEngine
+        Engine used for the comparison query.
+    comparer_table : str
+        Table name on the comparer engine.
+    where : str, optional
+        Optional SQL filter for the primary engine.
+    comparer_where : str, optional
+        Optional SQL filter for the comparer engine.
+
     Examples
     --------
-    >>> TableReconciliationValidator(
-    ...     comparer_engine=comparer,
-    ...     comparer_table="t2",
-    ... )
-    <TableReconciliationValidator>
+    Basic usage::
+
+        TableReconciliationValidator(
+            comparer_engine=comparer,
+            comparer_table="t2",
+        )
+
+    Apply filters when validating a subset of rows::
+
+        TableReconciliationValidator(
+            comparer_engine=comparer,
+            comparer_table="t2",
+            where="active = 1",
+            comparer_where="status = 'active'",
+        )
+        <TableReconciliationValidator>
     """
 
     def __init__(


### PR DESCRIPTION
## Summary
- expand reconciliation validator docstrings with detailed examples
- document built-in metric builders with examples
- outline reconciliation configuration patterns in README and cookbook

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f13d58844832aa7215c82ff885408