### PR TITLE
Raise error for single set metric column

### DIFF
--- a/src/expectations/metrics/registry.py
+++ b/src/expectations/metrics/registry.py
@@ -237,15 +237,9 @@ def _resolve_columns(col1: str, col2: Optional[str]) -> Tuple[str, str]:
         return col1, col2
 
     parts = [p.strip() for p in col1.split(",")]
-    if len(parts) == 1:
-        # Treat a single name as both columns.  This allows generic tests that
-        # iterate over all registered metrics to invoke the builder with a single
-        # column without raising an error.  Real callers should provide two
-        # distinct columns for set comparisons.
-        return parts[0], parts[0]
-    if len(parts) == 2:
-        return parts[0], parts[1]
-    raise ValueError("Expected two column names separated by a comma")
+    if len(parts) != 2:
+        raise ValueError("Expected two column names separated by a comma")
+    return parts[0], parts[1]
 
 
 @register_metric("set_overlap_pct")

--- a/tests/test_batch_builder_properties.py
+++ b/tests/test_batch_builder_properties.py
@@ -17,7 +17,15 @@ simple_predicate = st.one_of(
 )
 
 filter_strategy = st.one_of(st.none(), simple_predicate)
-metric_strategy = st.sampled_from(available_metrics())
+# Metrics like set comparisons require multiple columns. The batch builder only
+# supports single-column metrics, so exclude those multi-column metrics from the
+# strategy.
+_single_col_metrics = [
+    m
+    for m in available_metrics()
+    if m not in {"set_overlap_pct", "missing_values_cnt", "extra_values_cnt"}
+]
+metric_strategy = st.sampled_from(_single_col_metrics)
 
 
 @given(metric=metric_strategy, filter_sql=filter_strategy)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -19,5 +19,11 @@ def test_register_metric_duplicate_key():
 
 def test_builtin_metric_retrieval():
     for name in registry.available_metrics():
-        expr = registry.get_metric(name)("col")
+        builder = registry.get_metric(name)
+        if name in {"set_overlap_pct", "missing_values_cnt", "extra_values_cnt"}:
+            with pytest.raises(ValueError):
+                builder("col")
+            expr = builder("col1", "col2")
+        else:
+            expr = builder("col")
         assert isinstance(expr, exp.Expression)


### PR DESCRIPTION
## Summary
- `MetricRegistry._resolve_columns` now errors unless two column names are provided
- Update tests to handle metrics requiring multiple columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f1465a564832aabe733524309f5a8