### PR TITLE
Guard set_overlap_pct division by zero

### DIFF
--- a/src/expectations/metrics/registry.py
+++ b/src/expectations/metrics/registry.py
@@ -326,7 +326,10 @@ def set_overlap_pct(
     union_case = exp.Case().when(union_cond, exp.Literal.number(1))
     union_cnt = exp.Sum(this=union_case)
 
-    return exp.Div(this=inter_cnt, expression=union_cnt)
+    zero_union = exp.EQ(this=union_cnt.copy(), expression=exp.Literal.number(0))
+    div_expr = exp.Div(this=inter_cnt, expression=union_cnt.copy())
+
+    return exp.Case().when(zero_union, exp.null()).else_(div_expr)
 
 
 @register_metric("missing_values_cnt")

--- a/tests/test_set_metrics.py
+++ b/tests/test_set_metrics.py
@@ -28,6 +28,14 @@ def test_set_overlap_pct_mismatched_schema():
         _run_expr(eng, "t", expr)
 
 
+def test_set_overlap_pct_all_nulls():
+    eng = DuckDBEngine()
+    eng.register_dataframe("t", pd.DataFrame({"a": [None, None], "b": [None, None]}))
+    expr = get_metric("set_overlap_pct")("a", "b")
+    val = _run_expr(eng, "t", expr)
+    assert pd.isna(val)
+
+
 def test_set_overlap_pct_empty_table():
     eng = DuckDBEngine()
     eng.register_dataframe("t", pd.DataFrame({"a": [], "b": []}))


### PR DESCRIPTION
## Summary
- avoid dividing by zero in `set_overlap_pct`
- add unit test covering all-null inputs

## Testing
- `pytest tests/test_set_metrics.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f1808a75c832aa9cb1dca72ed1171