### PR TITLE
Add test for store connection context

### DIFF
--- a/src/utils/store_context.py
+++ b/src/utils/store_context.py
@@ -15,8 +15,15 @@ from src.expectations.store.duckdb import DuckDBResultStore
 
 @contextmanager
 def store_connection(store: DuckDBResultStore):
-    """Yield the underlying connection for ad-hoc read-only queries."""
+    """Yield the underlying connection for ad-hoc read-only queries.
+
+    The connection is intentionally left open after the context exits so it can
+    be reused by callers. This helper merely provides syntactic sugar around
+    the store's connection without managing its lifecycle.
+    """
+    conn = store.connection
     try:
-        yield store.connection
+        yield conn
     finally:
+        # The DuckDB connection remains open for the caller to manage.
         pass

--- a/tests/test_store_context.py
+++ b/tests/test_store_context.py
@@ -1,0 +1,10 @@
+from src.expectations.store.duckdb import DuckDBResultStore
+from src.utils.store_context import store_connection
+
+
+def test_store_connection_context_keeps_connection_open():
+    store = DuckDBResultStore()
+    with store_connection(store) as conn:
+        assert conn.execute("SELECT 1").fetchone()[0] == 1
+    # Connection should remain usable after the context manager exits
+    assert conn.execute("SELECT 1").fetchone()[0] == 1


### PR DESCRIPTION
## Summary
- clarify that `store_connection` does not manage connection lifecycle
- add regression test for `store_connection` ensuring connection remains open

## Testing
- `pytest tests/test_store_context.py`


------
https://chatgpt.com/codex/tasks/task_e_688f1adcee1c832ab3ea1e84c57c4439