### PR TITLE
Add reusable DuckDB fixtures and refactor tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+from src.expectations.engines.duckdb import DuckDBEngine
+from src.expectations.runner import ValidationRunner
+from .utils import sample_orders_df, sample_customers_df
+
+
+@pytest.fixture
+def duckdb_engine():
+    """Return a fresh DuckDBEngine instance."""
+    eng = DuckDBEngine()
+    yield eng
+    # ensure resources are released
+    eng.close()
+
+
+@pytest.fixture
+def sample_tables(duckdb_engine: DuckDBEngine):
+    """Register sample orders and customers tables on the provided engine."""
+    duckdb_engine.register_dataframe("orders", sample_orders_df())
+    duckdb_engine.register_dataframe("customers", sample_customers_df())
+    return duckdb_engine
+
+
+@pytest.fixture
+def validation_runner(sample_tables: DuckDBEngine):
+    """Provide a ValidationRunner wired to the sample DuckDB engine."""
+    return ValidationRunner({"duck": sample_tables})

--- a/tests/test_anomaly_validators.py
+++ b/tests/test_anomaly_validators.py
@@ -1,20 +1,16 @@
 import pandas as pd
 
-from src.expectations.engines.duckdb import DuckDBEngine
 from src.expectations.store import DuckDBResultStore
-from src.expectations.runner import ValidationRunner
 from src.expectations.validators.column import MetricDriftValidator
 from src.expectations.validators.custom import ColumnZScoreOutlierRowsValidator
 
 
-def _run(eng, table, validator, store=None):
-    runner = ValidationRunner({"duck": eng})
+def _run(runner, table, validator):
     return runner.run([("duck", table, validator)], run_id="test")[0]
 
 
-def test_metric_drift_validator(tmp_path):
-    eng = DuckDBEngine()
-    store = DuckDBResultStore(eng)
+def test_metric_drift_validator(duckdb_engine, validation_runner):
+    store = DuckDBResultStore(duckdb_engine)
     store.connection.execute("DELETE FROM statistics")
     # insert synthetic history
     for i, val in enumerate([11, 9, 10, 11, 9, 10, 10, 10, 11, 9]):
@@ -22,18 +18,17 @@ def test_metric_drift_validator(tmp_path):
             "INSERT INTO statistics VALUES (?, ?, ?, ?, ?, ?, ?)",
             (f"r{i}", "t", None, None, None, "row_cnt", val),
         )
-    eng.register_dataframe("t", pd.DataFrame({"a": range(15)}))
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": range(15)}))
     v = MetricDriftValidator(metric="row_cnt", column=None, result_store=store, window=10, z_thresh=3.0)
-    res = _run(eng, "t", v)
+    res = _run(validation_runner, "t", v)
     assert res.success is False
     assert v.details["z"] > 3
 
 
-def test_column_zscore_outlier_rows_validator():
-    eng = DuckDBEngine()
+def test_column_zscore_outlier_rows_validator(duckdb_engine, validation_runner):
     df = pd.DataFrame({"a": [1, 2, 3, 100]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
     v = ColumnZScoreOutlierRowsValidator(column="a", z_thresh=1.0)
-    res = _run(eng, "t", v)
+    res = _run(validation_runner, "t", v)
     assert res.success is False
     assert res.details["error_row_count"] == 1

--- a/tests/test_column_validators.py
+++ b/tests/test_column_validators.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import pytest
 
-from src.expectations.engines.duckdb import DuckDBEngine
-from src.expectations.runner import ValidationRunner
 from src.expectations.validators.column import (
     ColumnNotNull,
     ColumnNullPct,
@@ -17,33 +15,29 @@ from src.expectations.validators.column import (
 from src.expectations.validators.table import RowCountValidator
 
 
-def _run(eng, table, validator):
-    runner = ValidationRunner({"duck": eng})
+def _run(runner, table, validator):
     return runner.run([("duck", table, validator)], run_id="test")[0]
 
 
-def test_column_not_null_pass_fail():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t1", pd.DataFrame({"a": [1, 2]}))
-    eng.register_dataframe("t2", pd.DataFrame({"a": [1, None]}))
+def test_column_not_null_pass_fail(duckdb_engine, validation_runner):
+    duckdb_engine.register_dataframe("t1", pd.DataFrame({"a": [1, 2]}))
+    duckdb_engine.register_dataframe("t2", pd.DataFrame({"a": [1, None]}))
 
-    assert _run(eng, "t1", ColumnNotNull(column="a")).success is True
-    assert _run(eng, "t2", ColumnNotNull(column="a")).success is False
+    assert _run(validation_runner, "t1", ColumnNotNull(column="a")).success is True
+    assert _run(validation_runner, "t2", ColumnNotNull(column="a")).success is False
 
 
-def test_column_null_pct_threshold():
-    eng = DuckDBEngine()
+def test_column_null_pct_threshold(duckdb_engine, validation_runner):
     df = pd.DataFrame({"a": [1, None, None]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
 
-    assert _run(eng, "t", ColumnNullPct(column="a", max_null_pct=0.7)).success is True
-    assert _run(eng, "t", ColumnNullPct(column="a", max_null_pct=0.6)).success is False
+    assert _run(validation_runner, "t", ColumnNullPct(column="a", max_null_pct=0.7)).success is True
+    assert _run(validation_runner, "t", ColumnNullPct(column="a", max_null_pct=0.6)).success is False
 
 
-def test_column_distinct_count_ops():
-    eng = DuckDBEngine()
+def test_column_distinct_count_ops(duckdb_engine, validation_runner):
     df = pd.DataFrame({"a": [1, 1, 2, 3]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
 
     cases = [
         ("==", True),
@@ -53,7 +47,7 @@ def test_column_distinct_count_ops():
         ("<", False),
     ]
     for op, expected in cases:
-        res = _run(eng, "t", ColumnDistinctCount(column="a", expected=3, op=op))
+        res = _run(validation_runner, "t", ColumnDistinctCount(column="a", expected=3, op=op))
         assert res.success is expected
 
 
@@ -67,108 +61,101 @@ def test_column_distinct_count_ops():
         ("<", False),
     ],
 )
-def test_column_distinct_count_parametrized(op, expected):
-    eng = DuckDBEngine()
+def test_column_distinct_count_parametrized(duckdb_engine, validation_runner, op, expected):
     df = pd.DataFrame({"a": [1, 1, 2, 3]})
-    eng.register_dataframe("t", df)
-    res = _run(eng, "t", ColumnDistinctCount(column="a", expected=3, op=op))
+    duckdb_engine.register_dataframe("t", df)
+    res = _run(validation_runner, "t", ColumnDistinctCount(column="a", expected=3, op=op))
     assert res.success is expected
 
 
-def test_column_min_max_strict_vs_inclusive():
-    eng = DuckDBEngine()
+def test_column_min_max_strict_vs_inclusive(duckdb_engine, validation_runner):
     df = pd.DataFrame({"a": [1, 2, 3]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
 
-    assert _run(eng, "t", ColumnMin(column="a", min_value=1)).success is True
+    assert _run(validation_runner, "t", ColumnMin(column="a", min_value=1)).success is True
     assert (
-        _run(eng, "t", ColumnMin(column="a", min_value=1, strict=True)).success is False
+        _run(validation_runner, "t", ColumnMin(column="a", min_value=1, strict=True)).success
+        is False
     )
-    assert _run(eng, "t", ColumnMax(column="a", max_value=3)).success is True
+    assert _run(validation_runner, "t", ColumnMax(column="a", max_value=3)).success is True
     assert (
-        _run(eng, "t", ColumnMax(column="a", max_value=3, strict=True)).success is False
+        _run(validation_runner, "t", ColumnMax(column="a", max_value=3, strict=True)).success
+        is False
     )
 
 
-def test_column_value_in_set():
-    eng = DuckDBEngine()
+def test_column_value_in_set(duckdb_engine, validation_runner):
     df = pd.DataFrame({"a": ["A", "B", "A"]})
-    eng.register_dataframe("t", df)
-    ok = _run(eng, "t", ColumnValueInSet(column="a", allowed_values=["A", "B"]))
+    duckdb_engine.register_dataframe("t", df)
+    ok = _run(validation_runner, "t", ColumnValueInSet(column="a", allowed_values=["A", "B"]))
     assert ok.success is True
-    fail = _run(eng, "t", ColumnValueInSet(column="a", allowed_values=["A"]))
+    fail = _run(validation_runner, "t", ColumnValueInSet(column="a", allowed_values=["A"]))
     assert fail.success is False
 
 
-def test_column_matches_regex():
-    eng = DuckDBEngine()
+def test_column_matches_regex(duckdb_engine, validation_runner):
     df = pd.DataFrame({"a": ["x1", "y2", "z"]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
     v = ColumnMatchesRegex(column="a", pattern="^[a-z][0-9]")
-    assert _run(eng, "t", v).success is False
+    assert _run(validation_runner, "t", v).success is False
 
 
-def test_column_range():
-    eng = DuckDBEngine()
+def test_column_range(duckdb_engine, validation_runner):
     df = pd.DataFrame({"a": [1, 2, 3]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
     assert (
-        _run(eng, "t", ColumnRange(column="a", min_value=1, max_value=3)).success
+        _run(validation_runner, "t", ColumnRange(column="a", min_value=1, max_value=3)).success
         is True
     )
     assert (
         _run(
-            eng, "t", ColumnRange(column="a", min_value=1, max_value=3, strict=True)
+            validation_runner,
+            "t",
+            ColumnRange(column="a", min_value=1, max_value=3, strict=True),
         ).success
         is False
     )
 
 
-def test_column_greater_equal():
-    eng = DuckDBEngine()
+def test_column_greater_equal(duckdb_engine, validation_runner):
     df = pd.DataFrame({"a": [1, 2], "b": [2, 1]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
     v = ColumnGreaterEqual(column="b", other_column="a")
-    assert _run(eng, "t", v).success is False
+    assert _run(validation_runner, "t", v).success is False
 
 
-def test_column_min_where_clause():
-    eng = DuckDBEngine()
+def test_column_min_where_clause(duckdb_engine, validation_runner):
     df = pd.DataFrame({"a": [1, 3], "b": [0, 1]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
     v_pass = ColumnMin(column="a", min_value=3, where="b = 1")
-    assert _run(eng, "t", v_pass).success is True
+    assert _run(validation_runner, "t", v_pass).success is True
     v_fail = ColumnMin(column="a", min_value=2, where="b = 0")
-    assert _run(eng, "t", v_fail).success is False
+    assert _run(validation_runner, "t", v_fail).success is False
 
 
-def test_column_max_where_clause():
-    eng = DuckDBEngine()
+def test_column_max_where_clause(duckdb_engine, validation_runner):
     df = pd.DataFrame({"a": [3, 10], "b": [0, 1]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
     v_pass = ColumnMax(column="a", max_value=3, where="b = 0")
-    assert _run(eng, "t", v_pass).success is True
+    assert _run(validation_runner, "t", v_pass).success is True
     v_fail = ColumnMax(column="a", max_value=5, where="b = 1")
-    assert _run(eng, "t", v_fail).success is False
+    assert _run(validation_runner, "t", v_fail).success is False
 
-def test_where_clause_filters_rows():
-    eng = DuckDBEngine()
+
+def test_where_clause_filters_rows(duckdb_engine, validation_runner):
     df = pd.DataFrame({"a": [1, None], "b": [0, 1]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
     v_pass = RowCountValidator(min_rows=1, max_rows=1, where="b = 0")
-    res_pass = _run(eng, "t", v_pass)
+    res_pass = _run(validation_runner, "t", v_pass)
     assert res_pass.success is True
     v_fail = RowCountValidator(min_rows=1, max_rows=0, where="b = 1")
-    res_fail = _run(eng, "t", v_fail)
+    res_fail = _run(validation_runner, "t", v_fail)
     assert res_fail.success is False
 
 
-def test_row_count_where_clause():
-    eng = DuckDBEngine()
+def test_row_count_where_clause(duckdb_engine, validation_runner):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [1, 1, 2]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
     v = RowCountValidator(min_rows=1, max_rows=1, where="b = 2")
-    res = _run(eng, "t", v)
+    res = _run(validation_runner, "t", v)
     assert res.success is True
-
-

--- a/tests/test_end_to_end_workflow.py
+++ b/tests/test_end_to_end_workflow.py
@@ -1,15 +1,11 @@
 import pandas as pd
 
 from src.expectations.config.expectation import SLAConfig
-from src.expectations.runner import ValidationRunner
 from src.expectations.store import DuckDBResultStore
 from src.expectations.workflow import run_validations
 
-from tests.utils import setup_sample_engine
-
-
-def test_full_end_to_end_workflow(tmp_path):
-    eng = setup_sample_engine()
+def test_full_end_to_end_workflow(tmp_path, sample_tables, validation_runner):
+    eng = sample_tables
 
     sla_yaml = """
     sla_name: ecommerce
@@ -57,7 +53,7 @@ def test_full_end_to_end_workflow(tmp_path):
 
     sla_cfg = SLAConfig.from_yaml(path)
 
-    runner = ValidationRunner({"duck": eng})
+    runner = validation_runner
     store = DuckDBResultStore(eng)
 
     store.connection.execute("DELETE FROM runs")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,14 +1,12 @@
 import pandas as pd
 
-from src.expectations.engines.duckdb import DuckDBEngine
 from src.expectations.engines.base import BaseEngine
 
 
-def test_duckdb_list_columns():
-    eng = DuckDBEngine()
+def test_duckdb_list_columns(duckdb_engine):
     df = pd.DataFrame({"a": [1], "b": [2]})
-    eng.register_dataframe("t", df)
-    cols = set(eng.list_columns("t"))
+    duckdb_engine.register_dataframe("t", df)
+    cols = set(duckdb_engine.list_columns("t"))
     assert cols == {"a", "b"}
 
 

--- a/tests/test_metric_builders.py
+++ b/tests/test_metric_builders.py
@@ -2,50 +2,45 @@ import pandas as pd
 from pytest import approx
 from sqlglot import select
 
-from src.expectations.engines.duckdb import DuckDBEngine
 from src.expectations.metrics.registry import get_metric
 
 
-def _run_expr(engine: DuckDBEngine, table: str, expr):
+def _run_expr(engine, table: str, expr):
     sql = select(expr).from_(table)
     return engine.run_sql(sql).iloc[0, 0]
 
 
-def test_null_pct_sql():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [1, 2, None]}))
+def test_null_pct_sql(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [1, 2, None]}))
     expr = get_metric("null_pct")("a")
-    val = _run_expr(eng, "t", expr)
+    val = _run_expr(duckdb_engine, "t", expr)
     assert val == approx(1 / 3)
 
 
-def test_distinct_cnt():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [1, 1, 2]}))
+def test_distinct_cnt(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [1, 1, 2]}))
     expr = get_metric("distinct_cnt")("a")
-    val = _run_expr(eng, "t", expr)
+    val = _run_expr(duckdb_engine, "t", expr)
     assert val == 2
 
 
-def test_min_max():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [3, 1, 5]}))
+def test_min_max(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [3, 1, 5]}))
     min_expr = get_metric("min")("a").as_("mn")
     max_expr = get_metric("max")("a").as_("mx")
-    df = eng.run_sql(select(min_expr, max_expr).from_("t"))
+    df = duckdb_engine.run_sql(select(min_expr, max_expr).from_("t"))
     assert df.iloc[0]["mn"] == 1
     assert df.iloc[0]["mx"] == 5
 
 
-def test_extra_metrics():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [1, 2, None]}))
+def test_extra_metrics(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [1, 2, None]}))
 
     nn_expr = get_metric("non_null_cnt")("a")
     avg_expr = get_metric("avg")("a")
     stddev_expr = get_metric("stddev")("a")
 
-    df = eng.run_sql(
+    df = duckdb_engine.run_sql(
         select(nn_expr.as_("nn"), avg_expr.as_("avg"), stddev_expr.as_("sd")).from_("t")
     )
     assert df.iloc[0]["nn"] == 2
@@ -53,26 +48,24 @@ def test_extra_metrics():
     assert df.iloc[0]["sd"] == approx((0.5) ** 0.5)
 
 
-def test_pct_where_builder(tmp_path):
-    eng = DuckDBEngine()
+def test_pct_where_builder(tmp_path, duckdb_engine):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [1, 0, 1]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
     from src.expectations.metrics.registry import pct_where
 
     builder = pct_where("b = 1")
     expr = builder("a")
-    val = _run_expr(eng, "t", expr)
+    val = _run_expr(duckdb_engine, "t", expr)
     assert val == approx(2 / 3)
 
 
-def test_register_pct_where(tmp_path):
-    eng = DuckDBEngine()
+def test_register_pct_where(tmp_path, duckdb_engine):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [1, 0, 1]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
 
     from src.expectations.metrics.registry import get_metric, register_pct_where
 
     register_pct_where("b_is_one_pct", "b = 1")
     expr = get_metric("b_is_one_pct")("a")
-    val = _run_expr(eng, "t", expr)
+    val = _run_expr(duckdb_engine, "t", expr)
     assert val == approx(2 / 3)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import pytest
 
-from src.expectations.engines.duckdb import DuckDBEngine
-from src.expectations.runner import ValidationRunner
 from src.expectations.validators.column import ColumnNotNull, ColumnNullPct
 from src.expectations.validators.table import DuplicateRowValidator
 from src.expectations.validators.base import ValidatorBase
@@ -20,64 +18,56 @@ class FaultyValidator(ValidatorBase):
         return True
 
 
-def test_metric_grouping(monkeypatch):
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [1, 2, None]}))
+def test_metric_grouping(duckdb_engine, validation_runner, monkeypatch):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [1, 2, None]}))
 
     calls = []
-    original = eng.run_sql
+    original = duckdb_engine.run_sql
 
     def spy(sql):
         calls.append(sql)
         return original(sql)
 
-    monkeypatch.setattr(eng, "run_sql", spy)
+    monkeypatch.setattr(duckdb_engine, "run_sql", spy)
 
-    runner = ValidationRunner({"duck": eng})
     bindings = [
         ("duck", "t", ColumnNotNull(column="a")),
         ("duck", "t", ColumnNullPct(column="a", max_null_pct=1.0)),
     ]
-    runner.run(bindings, run_id="test")
+    validation_runner.run(bindings, run_id="test")
     assert len(calls) == 1
 
 
-def test_metric_and_custom_calls(monkeypatch):
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [1, 1]}))
+def test_metric_and_custom_calls(duckdb_engine, validation_runner, monkeypatch):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [1, 1]}))
     calls = []
-    original = eng.run_sql
+    original = duckdb_engine.run_sql
 
     def spy(sql):
         calls.append(sql)
         return original(sql)
 
-    monkeypatch.setattr(eng, "run_sql", spy)
+    monkeypatch.setattr(duckdb_engine, "run_sql", spy)
 
-    runner = ValidationRunner({"duck": eng})
     bindings = [
         ("duck", "t", ColumnNotNull(column="a")),
         ("duck", "t", DuplicateRowValidator(key_columns=["a"])),
     ]
-    runner.run(bindings, run_id="test")
+    validation_runner.run(bindings, run_id="test")
     assert len(calls) == 2
 
 
-def test_error_propagation(monkeypatch):
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [1]}))
+def test_error_propagation(duckdb_engine, validation_runner):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [1]}))
 
-    runner = ValidationRunner({"duck": eng})
-    res = runner.run([("duck", "t", FaultyValidator())], run_id="test")[0]
+    res = validation_runner.run([("duck", "t", FaultyValidator())], run_id="test")[0]
     assert res.success is False
     assert "error" in res.details
     assert "traceback" in res.details
 
-def test_metric_error_capture():
-    eng = DuckDBEngine()
-    runner = ValidationRunner({"duck": eng})
-    res = runner.run([("duck", "missing", ColumnNotNull(column="a"))], run_id="test")[0]
+
+def test_metric_error_capture(duckdb_engine, validation_runner):
+    res = validation_runner.run([("duck", "missing", ColumnNotNull(column="a"))], run_id="test")[0]
     assert res.success is False
     assert "error" in res.details
     assert "traceback" in res.details
-

--- a/tests/test_set_metrics.py
+++ b/tests/test_set_metrics.py
@@ -3,90 +3,79 @@ import pytest
 from pytest import approx
 from sqlglot import select
 
-from src.expectations.engines.duckdb import DuckDBEngine
 from src.expectations.metrics.registry import get_metric
 
 
-def _run_expr(engine: DuckDBEngine, table: str, expr):
+def _run_expr(engine, table: str, expr):
     sql = select(expr).from_(table)
     return engine.run_sql(sql).iloc[0, 0]
 
 
-def test_set_overlap_pct_with_nulls():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [1, None, 2], "b": [1, 2, 3]}))
+def test_set_overlap_pct_with_nulls(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [1, None, 2], "b": [1, 2, 3]}))
     expr = get_metric("set_overlap_pct")("a", "b")
-    val = _run_expr(eng, "t", expr)
+    val = _run_expr(duckdb_engine, "t", expr)
     assert val == approx(2 / 3)
 
 
-def test_set_overlap_pct_mismatched_schema():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [1, 2]}))
+def test_set_overlap_pct_mismatched_schema(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [1, 2]}))
     expr = get_metric("set_overlap_pct")("a", "b")
     with pytest.raises(RuntimeError):
-        _run_expr(eng, "t", expr)
+        _run_expr(duckdb_engine, "t", expr)
 
 
-def test_set_overlap_pct_all_nulls():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [None, None], "b": [None, None]}))
+def test_set_overlap_pct_all_nulls(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [None, None], "b": [None, None]}))
     expr = get_metric("set_overlap_pct")("a", "b")
-    val = _run_expr(eng, "t", expr)
+    val = _run_expr(duckdb_engine, "t", expr)
     assert pd.isna(val)
 
 
-def test_set_overlap_pct_empty_table():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [], "b": []}))
+def test_set_overlap_pct_empty_table(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [], "b": []}))
     expr = get_metric("set_overlap_pct")("a", "b")
-    val = _run_expr(eng, "t", expr)
+    val = _run_expr(duckdb_engine, "t", expr)
     assert pd.isna(val)
 
 
-def test_missing_values_cnt_with_nulls():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [None, 1, 3], "b": [1, 2, None]}))
+def test_missing_values_cnt_with_nulls(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [None, 1, 3], "b": [1, 2, None]}))
     expr = get_metric("missing_values_cnt")("a", "b")
-    val = _run_expr(eng, "t", expr)
+    val = _run_expr(duckdb_engine, "t", expr)
     assert val == 1
 
 
-def test_missing_values_cnt_mismatched_schema():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [1, 2]}))
+def test_missing_values_cnt_mismatched_schema(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [1, 2]}))
     expr = get_metric("missing_values_cnt")("a", "b")
     with pytest.raises(RuntimeError):
-        _run_expr(eng, "t", expr)
+        _run_expr(duckdb_engine, "t", expr)
 
 
-def test_missing_values_cnt_empty_table():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [], "b": []}))
+def test_missing_values_cnt_empty_table(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [], "b": []}))
     expr = get_metric("missing_values_cnt")("a", "b")
-    val = _run_expr(eng, "t", expr)
+    val = _run_expr(duckdb_engine, "t", expr)
     assert pd.isna(val)
 
 
-def test_extra_values_cnt_with_nulls():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [None, 1, 3], "b": [1, 2, None]}))
+def test_extra_values_cnt_with_nulls(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [None, 1, 3], "b": [1, 2, None]}))
     expr = get_metric("extra_values_cnt")("a", "b")
-    val = _run_expr(eng, "t", expr)
+    val = _run_expr(duckdb_engine, "t", expr)
     assert val == 1
 
 
-def test_extra_values_cnt_mismatched_schema():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [1, 2]}))
+def test_extra_values_cnt_mismatched_schema(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [1, 2]}))
     expr = get_metric("extra_values_cnt")("a", "b")
     with pytest.raises(RuntimeError):
-        _run_expr(eng, "t", expr)
+        _run_expr(duckdb_engine, "t", expr)
 
 
-def test_extra_values_cnt_empty_table():
-    eng = DuckDBEngine()
-    eng.register_dataframe("t", pd.DataFrame({"a": [], "b": []}))
+def test_extra_values_cnt_empty_table(duckdb_engine):
+    duckdb_engine.register_dataframe("t", pd.DataFrame({"a": [], "b": []}))
     expr = get_metric("extra_values_cnt")("a", "b")
-    val = _run_expr(eng, "t", expr)
+    val = _run_expr(duckdb_engine, "t", expr)
     assert pd.isna(val)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,20 +1,18 @@
 import pandas as pd
 
-from src.expectations.engines.duckdb import DuckDBEngine
 from src.expectations.stats import TableStatsCollector
 from src.expectations.store import DuckDBResultStore
 from src.expectations.result_model import RunMetadata
 
 
-def test_collect_and_persist_stats(tmp_path):
-    eng = DuckDBEngine()
+def test_collect_and_persist_stats(duckdb_engine):
     df = pd.DataFrame({"a": [1, 2, None], "b": [5, 6, 7]})
-    eng.register_dataframe("t", df)
+    duckdb_engine.register_dataframe("t", df)
 
-    store = DuckDBResultStore(eng)
+    store = DuckDBResultStore(duckdb_engine)
     store.connection.execute("DELETE FROM statistics")
 
-    collector = TableStatsCollector({"duck": eng})
+    collector = TableStatsCollector({"duck": duckdb_engine})
     run = RunMetadata(suite_name="stats")
     stats = collector.collect("duck", "t", run_id=run.run_id)
     store.persist_stats(run, stats)


### PR DESCRIPTION
## Summary
- add pytest fixtures for DuckDB engines, sample tables, and a ValidationRunner
- refactor tests to use shared fixtures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f1be59f90832a8feb41c1fcbe6912