### PR TITLE
Add validation for non-ValidatorBase types and extend SLA config tests

### DIFF
--- a/src/expectations/config/expectation.py
+++ b/src/expectations/config/expectation.py
@@ -63,7 +63,13 @@ class ExpectationSuiteConfig(BaseModel):
                 cls = SqlErrorRowsValidator
             else:
                 cls = _resolve_validator_class(cfg.expectation_type)
-            if not issubclass(cls, ValidatorBase):
+            try:
+                is_validator = issubclass(cls, ValidatorBase)
+            except TypeError as exc:
+                raise TypeError(
+                    f"{cfg.expectation_type} is not a ValidatorBase"
+                ) from exc
+            if not is_validator:
                 raise TypeError(f"{cfg.expectation_type} is not a ValidatorBase")
 
             init_kwargs = dict(getattr(cfg, "kwargs", {}) or {})


### PR DESCRIPTION
## Summary
- ensure `ExpectationSuiteConfig.build_validators` raises a clear `TypeError` when a resolved class is not a `ValidatorBase`
- add tests covering non-ValidatorBase types in suites
- extend `SLAConfig` tests for JSON loading, malformed config files, and unsupported extensions

## Testing
- `pytest tests/test_expectation_suite.py tests/test_sla_config.py`


------
https://chatgpt.com/codex/tasks/task_e_688f23a533d8832a879752870e2ef6ec