### PR TITLE
docs: convert cookbook to RST and index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,3 +6,4 @@ Validator Documentation
 
    validators
    streamlit
+   cookbook


### PR DESCRIPTION
## Summary
- rewrite cookbook in pure reStructuredText with proper code blocks
- link the cookbook from the main documentation index for discovery

## Testing
- `make docs`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f293323cc832a8be4a5063a632285