### PR TITLE
Validate suite names in SuiteStore

### DIFF
--- a/src/service/api.py
+++ b/src/service/api.py
@@ -30,13 +30,18 @@ class SuiteStore:
         return [p.stem for p in self.base_path.glob("*.yml")]
 
     def load(self, name: str) -> ExpectationSuiteConfig:
+        if "/" in name or "\\" in name or Path(name).name != name:
+            raise ValueError(f"Invalid suite name: {name}")
         path = self.base_path / f"{name}.yml"
         if not path.exists():
             raise FileNotFoundError(name)
         return ExpectationSuiteConfig.from_yaml(path)
 
     def save(self, suite: ExpectationSuiteConfig) -> None:
-        path = self.base_path / f"{suite.suite_name}.yml"
+        name = suite.suite_name
+        if "/" in name or "\\" in name or Path(name).name != name:
+            raise ValueError(f"Invalid suite name: {name}")
+        path = self.base_path / f"{name}.yml"
         path.write_text(suite.to_yaml())
 
 

--- a/tests/test_suite_store.py
+++ b/tests/test_suite_store.py
@@ -1,0 +1,27 @@
+import pytest
+from src.service.api import SuiteStore
+from src.expectations.config.expectation import ExpectationSuiteConfig
+from pathlib import Path
+
+
+@pytest.mark.parametrize("invalid_name", ["../evil", "foo/bar", "foo\\bar"])
+def test_save_rejects_invalid_names(tmp_path, invalid_name):
+    store = SuiteStore(tmp_path / "suites")
+    cfg = ExpectationSuiteConfig(suite_name=invalid_name, engine="duck", table="t", expectations=[])
+    with pytest.raises(ValueError):
+        store.save(cfg)
+    assert not any((tmp_path / "suites").glob("*") )
+    assert not list(tmp_path.glob("*.yml"))
+
+
+@pytest.mark.parametrize("invalid_name", ["../evil", "foo/bar", "foo\\bar"])
+def test_load_rejects_invalid_names(tmp_path, invalid_name):
+    store = SuiteStore(tmp_path / "suites")
+    outside = tmp_path / f"{Path(invalid_name).name}.yml"
+    outside_cfg = ExpectationSuiteConfig(suite_name="outside", engine="duck", table="t", expectations=[])
+    outside.write_text(outside_cfg.to_yaml())
+
+    with pytest.raises(ValueError):
+        store.load(invalid_name)
+    assert outside.exists()  # ensure file wasn't altered
+    assert not any((tmp_path / "suites").glob("*") )


### PR DESCRIPTION
## Summary
- guard SuiteStore load/save against path traversal by rejecting names with separators or normalization issues
- add tests ensuring invalid suite names raise errors and don't touch paths outside the base directory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fe673d634832ab24a0faef26bfda9