### PR TITLE
Use package imports and add service import test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "validator"
+version = "0.1.0"
+
+[tool.setuptools.packages.find]
+include = ["src*"]

--- a/src/service/api.py
+++ b/src/service/api.py
@@ -4,19 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List
-import os
-import sys
 
 from fastapi import FastAPI, HTTPException
 
-try:
-    from src.expectations.config.expectation import ExpectationSuiteConfig
-except ImportError:  # pragma: no cover - dev dependency
-    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-    from src.expectations.config.expectation import ExpectationSuiteConfig
-from src.expectations.runner import ValidationRunner
-from src.expectations.store.base import BaseResultStore
-from src.expectations.workflow import run_validations
+from ..expectations.config.expectation import ExpectationSuiteConfig
+from ..expectations.runner import ValidationRunner
+from ..expectations.store.base import BaseResultStore
+from ..expectations.workflow import run_validations
 
 
 class SuiteStore:

--- a/src/service/streamlit_app.py
+++ b/src/service/streamlit_app.py
@@ -1,9 +1,7 @@
 """Simple Streamlit UI on top of the :mod:`validator.service` API."""
-
 from __future__ import annotations
 
 import os
-import sys
 from typing import List, Dict, Any
 from pathlib import Path
 import json
@@ -11,7 +9,6 @@ import json
 import pandas as pd
 import requests
 import streamlit as st
-import sys
 
 from .widgets import widget_for
 
@@ -22,11 +19,7 @@ except Exception:  # pragma: no cover - dev dependency
 
 import duckdb
 
-try:
-    from src.expectations.config.expectation import ExpectationSuiteConfig
-except ImportError:  # pragma: no cover - dev dependency
-    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-    from src.expectations.config.expectation import ExpectationSuiteConfig
+from ..expectations.config.expectation import ExpectationSuiteConfig
 
 
 SERVICE_URL = os.getenv("SERVICE_URL", "http://localhost:8000")

--- a/tests/test_expectation_suite.py
+++ b/tests/test_expectation_suite.py
@@ -2,14 +2,7 @@ import json
 import tempfile
 import yaml
 import pytest
-import os
-import sys
-
-try:
-    from src.expectations.config.expectation import ExpectationSuiteConfig
-except ImportError:  # pragma: no cover - dev dependency
-    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-    from src.expectations.config.expectation import ExpectationSuiteConfig
+from src.expectations.config.expectation import ExpectationSuiteConfig
 from src.expectations.validators.column import ColumnNotNull
 import src.expectations.validators.column as column_mod
 import src.expectations.config.expectation as expectation_mod

--- a/tests/test_integration_suite.py
+++ b/tests/test_integration_suite.py
@@ -1,11 +1,6 @@
 import pandas as pd
-import os
-import sys
-try:
-    from src.expectations.config.expectation import ExpectationSuiteConfig
-except ImportError:  # pragma: no cover - dev dependency
-    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-    from src.expectations.config.expectation import ExpectationSuiteConfig
+
+from src.expectations.config.expectation import ExpectationSuiteConfig
 from src.expectations.validators.custom import SqlErrorRowsValidator
 from src.expectations.validators.table import RowCountValidator, DuplicateRowValidator
 

--- a/tests/test_result_store.py
+++ b/tests/test_result_store.py
@@ -77,13 +77,7 @@ def test_duckdb_store_persist_sla(tmp_path):
     store.connection.execute("DELETE FROM results")
     store.connection.execute("DELETE FROM slas")
 
-    import os
-    import sys
-    try:
-        from src.expectations.config.expectation import SLAConfig, ExpectationSuiteConfig
-    except ImportError:  # pragma: no cover - dev dependency
-        sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-        from src.expectations.config.expectation import SLAConfig, ExpectationSuiteConfig
+    from src.expectations.config.expectation import SLAConfig, ExpectationSuiteConfig
 
     sla_cfg = SLAConfig(
         sla_name="sla1",

--- a/tests/test_service_imports.py
+++ b/tests/test_service_imports.py
@@ -1,0 +1,7 @@
+import importlib
+
+
+def test_service_module_imports():
+    """Modules should be importable without path hacks."""
+    importlib.import_module("src.service.api")
+    importlib.import_module("src.service.streamlit_app")

--- a/tests/test_sql_error_rows.py
+++ b/tests/test_sql_error_rows.py
@@ -1,14 +1,8 @@
-import os
-import sys
 import pandas as pd
 
 from src.expectations.validators.custom import SqlErrorRowsValidator
 from src.expectations.validators.column import ColumnNotNull
-try:
-    from src.expectations.config.expectation import ExpectationSuiteConfig
-except ImportError:  # pragma: no cover - dev dependency
-    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-    from src.expectations.config.expectation import ExpectationSuiteConfig
+from src.expectations.config.expectation import ExpectationSuiteConfig
 
 
 def _run(runner, table, validator):


### PR DESCRIPTION
## Summary
- remove sys.path hacks in service modules and rely on package-relative imports
- add pyproject metadata to make src package importable
- exercise service module imports in a regression test

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fe684b434832ab87d719378ae1923