### PR TITLE
Add percentile metric and validator

### DIFF
--- a/tests/test_metric_builders.py
+++ b/tests/test_metric_builders.py
@@ -48,6 +48,17 @@ def test_extra_metrics(duckdb_engine):
     assert df.iloc[0]["sd"] == approx((0.5) ** 0.5)
 
 
+def test_register_percentile(duckdb_engine):
+    df = pd.DataFrame({"a": [1, 2, 3, 4, 5]})
+    duckdb_engine.register_dataframe("t", df)
+    from src.expectations.metrics.registry import get_metric, register_percentile
+
+    register_percentile(0.9)
+    expr = get_metric("pct_90")("a")
+    val = _run_expr(duckdb_engine, "t", expr)
+    assert val == approx(df["a"].quantile(0.9))
+
+
 def test_pct_where_builder(tmp_path, duckdb_engine):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [1, 0, 1]})
     duckdb_engine.register_dataframe("t", df)


### PR DESCRIPTION
## Summary
- add percentile metric builder with registration helper
- support percentile checks via new ColumnPercentile validator
- test percentile metric and validator on synthetic data

## Testing
- `pytest tests/test_metric_builders.py::test_register_percentile tests/test_column_validators.py::test_column_percentile -q`


------
https://chatgpt.com/codex/tasks/task_e_688fea3ca6fc832a8ebabf31fcbe3a3d