### PR TITLE
Add foreign key reconciliation validator

### DIFF
--- a/src/expectations/validators/reconciliation.py
+++ b/src/expectations/validators/reconciliation.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from typing import Sequence
 
 import pandas as pd
+import re
 
 from src.expectations.engines.base import BaseEngine
 from src.expectations.metrics.batch_builder import MetricBatchBuilder, MetricRequest
+from src.expectations.metrics.registry import get_metric
 from src.expectations.utils.mappings import ColumnMapping, validate_column_mapping
 from src.expectations.utils.comparer import run_metrics
 from src.expectations.validators.base import ValidatorBase
@@ -224,3 +226,73 @@ class TableReconciliationValidator(ValidatorBase):
 
         self.details = {"primary": primary_cnt, "comparer": comparer_cnt}
         return primary_cnt == comparer_cnt
+
+
+class ForeignKeyReconciliationValidator(ValidatorBase):
+    """Validate foreign key references between two tables on the same engine.
+
+    The validator checks that all values in the *foreign* table exist in the
+    *primary* table using the :func:`missing_values_cnt` metric.  The validator
+    succeeds when there are no missing references.
+
+    Parameters
+    ----------
+    column_map : :class:`~src.expectations.utils.mappings.ColumnMapping`
+        Mapping between the primary key column and the foreign key column.  If
+        ``comparer`` is ``None`` the primary column name is used for both
+        tables.
+    primary_engine : BaseEngine
+        Engine used to validate the column mapping on construction.
+    primary_table : str
+        Table containing the primary key values.
+    foreign_table : str
+        Table containing foreign key references.
+    """
+
+    def __init__(
+        self,
+        *,
+        column_map: ColumnMapping,
+        primary_engine: BaseEngine,
+        primary_table: str,
+        foreign_table: str,
+    ) -> None:
+        super().__init__()
+        self.column_map = column_map
+        self.primary_table = primary_table
+        self.foreign_table = foreign_table
+
+        # Validate that both columns exist on the engine
+        validate_column_mapping(
+            column_map,
+            primary_engine,
+            primary_table,
+            primary_engine,
+            foreign_table,
+        )
+
+    # ---- ValidatorBase interface ------------------------------------
+    @classmethod
+    def kind(cls) -> str:
+        return "custom"
+
+    def custom_sql(self, table: str):
+        foreign_table = table or self.foreign_table
+        primary_col = self.column_map.primary
+        foreign_col = self.column_map.comparer or self.column_map.primary
+        expr = get_metric("missing_values_cnt")("a", "b").sql()
+        expr = re.sub(r"\ba\b", f"p.{primary_col}", expr)
+        expr = re.sub(r"\bb\b", f"f.{foreign_col}", expr)
+        return (
+            f"SELECT {expr} AS missing FROM {foreign_table} f "
+            f"LEFT JOIN {self.primary_table} p ON p.{primary_col} = f.{foreign_col}"
+        )
+
+    def interpret(self, df: pd.DataFrame) -> bool:
+        missing = 0
+        if not df.empty:
+            val = df.iloc[0]["missing"]
+            if val is not None and not pd.isna(val):
+                missing = int(val)
+        self.details = {"missing_values_cnt": missing}
+        return missing == 0


### PR DESCRIPTION
## Summary
- support foreign key reconciliation via `ForeignKeyReconciliationValidator`
- exercise foreign key checks in reconciliation validator tests

## Testing
- `pytest tests/test_reconciliation_validators.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ff1ad3344832aaf84883b26cc2b78