### PR TITLE
Add column uniqueness validator

### DIFF
--- a/docs/validators.rst
+++ b/docs/validators.rst
@@ -171,6 +171,22 @@ Column mappings can rename and cast values::
     )
     <ColumnReconciliationValidator>
 
+ColumnUniquenessValidator
+------------------------
+
+**Signature**::
+
+    ColumnUniquenessValidator(column: 'str', where: 'str | None' = None)
+
+Passes when ``COUNT(DISTINCT column)`` equals ``COUNT(*)``.
+
+Example YAML:
+
+.. code-block:: yaml
+
+   - expectation_type: ColumnUniquenessValidator
+     column: user_id
+
 ColumnValueInSet
 ----------------
 


### PR DESCRIPTION
## Summary
- add ColumnUniquenessValidator comparing distinct and total row counts
- document ColumnUniquenessValidator with YAML example
- test column uniqueness and YAML parsing

## Testing
- `pytest tests/test_column_validators.py`

------
https://chatgpt.com/codex/tasks/task_e_688ff4a0892c832a8e97c75fef8a7322