### PR TITLE
Add column duplicate metric and convert uniqueness validator

### DIFF
--- a/src/expectations/metrics/registry.py
+++ b/src/expectations/metrics/registry.py
@@ -11,11 +11,12 @@ additional metrics at import time via the :func:`register_metric` decorator.
 
 Built-ins provided out-of-the-box
 ---------------------------------
-key           | meaning                               | expression
---------------|---------------------------------------|------------------------------------
-``null_pct``  | percentage of NULL values             | ``SUM(CASE WHEN col IS NULL THEN 1 END) / COUNT(*)``
-``distinct_cnt`` | count of distinct values            | ``COUNT(DISTINCT col)``
-``row_cnt``   | total row count (ignores *col* arg)   | ``COUNT(*)``
+key                | meaning                               | expression
+------------------|---------------------------------------|------------------------------------
+``null_pct``       | percentage of NULL values             | ``SUM(CASE WHEN col IS NULL THEN 1 END) / COUNT(*)``
+``distinct_cnt``   | count of distinct values              | ``COUNT(DISTINCT col)``
+``row_cnt``        | total row count (ignores *col* arg)   | ``COUNT(*)``
+``duplicate_cnt``  | count of duplicate values             | ``COUNT(*) - COUNT(DISTINCT col)``
 
 """
 
@@ -146,6 +147,15 @@ def _row_cnt(_: str) -> exp.Expression:
     'COUNT(*)'
     """
     return exp.Count(this=exp.Star())
+
+
+@register_metric("duplicate_cnt")
+def _duplicate_cnt(column: str) -> exp.Expression:
+    """Number of duplicate values in ``column``."""
+
+    total = _row_cnt(column)
+    distinct = _distinct_cnt(column)
+    return exp.Sub(this=total, expression=distinct)
 
 
 @register_metric("duplicate_row_cnt")

--- a/src/expectations/validators/column.py
+++ b/src/expectations/validators/column.py
@@ -7,28 +7,16 @@ batch-execution architecture.
 
 * All classes inherit :class:`ColumnMetricValidator` which implements
   the boilerplate for metric-type validators.
-* Each validator registers (or re-uses) a metric key in
-  ``src.expectations.metrics.registry`` and provides `interpret()` logic.
-
-New metrics added here:
-    - ``min``      → MIN(column)
-    - ``max``      → MAX(column)
-    - ``row_cnt``  → COUNT(*)
+* Each validator re-uses a metric key in ``src.expectations.metrics.registry``
+  and provides ``interpret()`` logic.
 """
 
 from __future__ import annotations
 
 from typing import Any, Optional
 
-import pandas as pd
-from sqlglot import exp
-
 from src.expectations.metrics.batch_builder import MetricRequest
-from src.expectations.metrics.registry import (
-    register_metric,
-    get_metric,
-    register_percentile,
-)
+from src.expectations.metrics.registry import register_percentile
 from src.expectations.validators.base import ValidatorBase
 
 
@@ -396,18 +384,6 @@ class ColumnGreaterEqual(ColumnMetricValidator):
         else:
             self.invalid_cnt = int(value)
         return self.invalid_cnt == 0
-
-
-@register_metric("duplicate_cnt")
-def _duplicate_cnt(column: str) -> exp.Expression:
-    """Number of duplicate values in ``column``.
-
-    Computed as ``row_cnt - distinct_cnt`` for the given column.
-    """
-
-    total = get_metric("row_cnt")(column)
-    distinct = get_metric("distinct_cnt")(column)
-    return exp.Sub(this=total, expression=distinct)
 
 
 class ColumnUniquenessValidator(ColumnMetricValidator):

--- a/tests/test_column_validators.py
+++ b/tests/test_column_validators.py
@@ -135,13 +135,18 @@ def test_column_greater_equal(duckdb_engine, validation_runner):
 def test_column_uniqueness_validator(duckdb_engine, validation_runner):
     df_unique = pd.DataFrame({"a": [1, 2, 3]})
     duckdb_engine.register_dataframe("t1", df_unique)
-    ok = _run(validation_runner, "t1", ColumnUniquenessValidator(column="a"))
+    v_ok = ColumnUniquenessValidator(column="a")
+    ok = _run(validation_runner, "t1", v_ok)
     assert ok.success is True
+    assert v_ok.duplicate_cnt == 0
+    assert v_ok.kind() == "metric"
 
     df_dup = pd.DataFrame({"a": [1, 1, 2]})
     duckdb_engine.register_dataframe("t2", df_dup)
-    fail = _run(validation_runner, "t2", ColumnUniquenessValidator(column="a"))
+    v_fail = ColumnUniquenessValidator(column="a")
+    fail = _run(validation_runner, "t2", v_fail)
     assert fail.success is False
+    assert v_fail.duplicate_cnt == 1
 
 
 def test_column_length_basic_pass_fail(duckdb_engine, validation_runner):

--- a/tests/test_duplicate_row_metric.py
+++ b/tests/test_duplicate_row_metric.py
@@ -2,7 +2,6 @@ import pandas as pd
 from sqlglot import select
 
 from src.expectations.metrics.registry import get_metric
-from src.expectations.validators import column  # noqa: F401  # ensure metric registration
 
 
 def _run_expr(engine, table: str, expr):

--- a/tests/test_duplicate_row_metric.py
+++ b/tests/test_duplicate_row_metric.py
@@ -2,6 +2,7 @@ import pandas as pd
 from sqlglot import select
 
 from src.expectations.metrics.registry import get_metric
+from src.expectations.validators import column  # noqa: F401  # ensure metric registration
 
 
 def _run_expr(engine, table: str, expr):
@@ -21,5 +22,21 @@ def test_duplicate_row_metric_no_dups(duckdb_engine):
     df = pd.DataFrame({"a": [1, 2], "b": [1, 2]})
     duckdb_engine.register_dataframe("t", df)
     expr = get_metric("duplicate_row_cnt")("a,b")
+    val = _run_expr(duckdb_engine, "t", expr)
+    assert val == 0
+
+
+def test_duplicate_cnt_metric_counts_duplicates(duckdb_engine):
+    df = pd.DataFrame({"a": [1, 1, 2, 3, 3]})
+    duckdb_engine.register_dataframe("t", df)
+    expr = get_metric("duplicate_cnt")("a")
+    val = _run_expr(duckdb_engine, "t", expr)
+    assert val == 2
+
+
+def test_duplicate_cnt_metric_no_dups(duckdb_engine):
+    df = pd.DataFrame({"a": [1, 2]})
+    duckdb_engine.register_dataframe("t", df)
+    expr = get_metric("duplicate_cnt")("a")
     val = _run_expr(duckdb_engine, "t", expr)
     assert val == 0


### PR DESCRIPTION
## Summary
- add `duplicate_cnt` metric for counting column duplicates
- refactor `ColumnUniquenessValidator` to metric-based implementation
- test duplicate count metric and metric-based uniqueness validator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689070701ac4832aa4e1d179ca2d8ad9