### PR TITLE
feat: add duplicate row metric and batch test

### DIFF
--- a/src/expectations/metrics/batch_builder.py
+++ b/src/expectations/metrics/batch_builder.py
@@ -33,7 +33,7 @@ class MetricRequest:
     MetricRequest(column='id', metric='row_cnt', alias='cnt', filter_sql=None)
     """
 
-    column: str
+    column: "str | Sequence[str]"
     metric: str
     alias: str
     filter_sql: Optional[str] = None  # optional per-metric WHERE

--- a/src/expectations/metrics/registry.py
+++ b/src/expectations/metrics/registry.py
@@ -23,7 +23,7 @@ key                | meaning                               | expression
 from __future__ import annotations
 
 import threading
-from typing import Callable, Dict, Tuple, Optional
+from typing import Callable, Dict, Tuple, Optional, Sequence
 
 from sqlglot import exp
 from src.expectations.metrics.utils import validate_filter_sql
@@ -159,11 +159,14 @@ def _duplicate_cnt(column: str) -> exp.Expression:
 
 
 @register_metric("duplicate_row_cnt")
-def _duplicate_row_cnt(columns: str) -> exp.Expression:
-    """Count duplicate groups based on ``columns``.
+def _duplicate_row_cnt(columns: "str | Sequence[str]") -> exp.Expression:
+    """Count duplicate groups based on *columns*.
 
-    ``columns`` may be a comma-separated list of key columns. The metric returns
-    the number of groups that contain more than one row.
+    Parameters
+    ----------
+    columns:
+        Either a comma-separated ``str`` or a sequence of key column names.  The
+        metric returns the number of groups that contain more than one row.
 
     Examples
     --------
@@ -171,7 +174,10 @@ def _duplicate_row_cnt(columns: str) -> exp.Expression:
     'COUNT(*) - COUNT(DISTINCT a, b)'
     """
 
-    keys = [c.strip() for c in columns.split(",") if c.strip()]
+    if isinstance(columns, str):
+        keys = [c.strip() for c in columns.split(",") if c.strip()]
+    else:
+        keys = [c.strip() for c in columns if c.strip()]
     if not keys:
         raise ValueError("duplicate_row_cnt requires at least one column")
 

--- a/src/expectations/validators/table.py
+++ b/src/expectations/validators/table.py
@@ -85,7 +85,7 @@ class DuplicateRowValidator(ValidatorBase):
 
     def metric_request(self) -> MetricRequest:
         return MetricRequest(
-            column=",".join(self.key_cols),
+            column=self.key_cols,
             metric="duplicate_row_cnt",
             alias=self.runtime_id,
         )


### PR DESCRIPTION
## Summary
- allow `duplicate_row_cnt` metric to accept a sequence of key columns
- verify that multiple `DuplicateRowValidator` instances execute in a single batch query
- support sequence-valued `column` fields in `MetricRequest`

## Testing
- `pytest tests/test_duplicate_row_metric.py tests/test_runner.py::test_multiple_duplicate_row_validators_batched -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689077fd83d4832aab10a28470fed09f