### PR TITLE
refactor: use metric for PK uniqueness

### DIFF
--- a/src/expectations/validators/table.py
+++ b/src/expectations/validators/table.py
@@ -15,7 +15,6 @@ from typing import List, Sequence
 
 import pandas as pd
 
-from sqlglot import exp
 
 from src.expectations.metrics.batch_builder import MetricRequest
 from src.expectations.validators.base import ValidatorBase
@@ -116,16 +115,14 @@ class PrimaryKeyUniquenessValidator(ValidatorBase):
 
     @classmethod
     def kind(cls):
-        return "custom"
+        return "metric"
 
-    def custom_sql(self, table: str):
-        distinct = exp.Count(
-            this=exp.Distinct(expressions=[exp.column(c) for c in self.key_cols])
+    def metric_request(self) -> MetricRequest:
+        return MetricRequest(
+            column=self.key_cols,
+            metric="duplicate_row_cnt",
+            alias=self.runtime_id,
         )
-        diff = exp.Sub(this=exp.Count(this=exp.Star()), expression=distinct).as_(
-            "dup_cnt"
-        )
-        return exp.select(diff).from_(table)
 
     def interpret(self, value) -> bool:
         if isinstance(value, pd.DataFrame):

--- a/tests/test_duplicate_row_metric.py
+++ b/tests/test_duplicate_row_metric.py
@@ -17,6 +17,14 @@ def test_duplicate_row_metric_counts_groups(duckdb_engine):
     assert val == 2
 
 
+def test_duplicate_row_metric_counts_all_duplicates(duckdb_engine):
+    df = pd.DataFrame({"a": [1, 1, 1, 2, 2, 3], "b": [1, 1, 1, 2, 2, 3]})
+    duckdb_engine.register_dataframe("t", df)
+    expr = get_metric("duplicate_row_cnt")("a,b")
+    val = _run_expr(duckdb_engine, "t", expr)
+    assert val == 3
+
+
 def test_duplicate_row_metric_no_dups(duckdb_engine):
     df = pd.DataFrame({"a": [1, 2], "b": [1, 2]})
     duckdb_engine.register_dataframe("t", df)

--- a/tests/test_table_validators.py
+++ b/tests/test_table_validators.py
@@ -66,6 +66,15 @@ def test_primary_key_uniqueness(duckdb_engine, validation_runner):
     )
 
 
+def test_primary_key_uniqueness_duplicate_count(duckdb_engine, validation_runner):
+    df = pd.DataFrame({"id": [1, 1, 1, 2, 2]})
+    duckdb_engine.register_dataframe("t", df)
+    v = PrimaryKeyUniquenessValidator(key_columns=["id"])
+    res = _run(validation_runner, "t", v)
+    assert res.success is False
+    assert v.duplicate_cnt == 3
+
+
 def test_table_freshness(duckdb_engine, validation_runner):
     now = pd.Timestamp.utcnow()
     fresh = pd.DataFrame({"ts": [now]})


### PR DESCRIPTION
## Summary
- migrate PrimaryKeyUniquenessValidator to metric `duplicate_row_cnt`
- extend duplicate row tests for multiple duplicates
- ensure primary-key validator batches with metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68907f07203c832a91a8e91d1fed27e3