### PR TITLE
docs: note validator batching

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -65,6 +65,8 @@ a metric via the ``_metric_key`` attribute and interpret the resulting value.
             self.active_pct = float(value)
             return self.active_pct > 0.95
 
+.. _metrics-batching:
+
 Batch execution
 ---------------
 

--- a/docs/validators.rst
+++ b/docs/validators.rst
@@ -11,6 +11,9 @@ modules under ``src/expectations/validators``:
 
 Validators are executed by the :doc:`runner` and can emit useful
 :doc:`metrics` or participate in :doc:`reconciliation` workflows.
+Metric-based validators targeting the same table and engine are
+batched and executed in a single query to reduce round-trips. See
+:ref:`metrics-batching` for more detail.
 
 ColumnDistinctCount
 -------------------


### PR DESCRIPTION
## Summary
- document that metric-based validators are batched into a single query per table/engine
- add anchor for metric batching documentation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890830ee15c832aac7fc5a27523abea